### PR TITLE
Make _frame.create_compression_context raise TypeError on bad arguments

### DIFF
--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -82,9 +82,7 @@ PyDoc_STRVAR(create_compression_context__doc,
             );
 
 static PyObject *
-create_compression_context (PyObject * Py_UNUSED (self),
-                            PyObject * Py_UNUSED (args),
-                            PyObject * Py_UNUSED (keywds))
+create_compression_context (PyObject * Py_UNUSED (self))
 {
   struct compression_context * context;
   LZ4F_errorCode_t result;
@@ -847,7 +845,7 @@ static PyMethodDef module_methods[] =
 {
   {
     "create_compression_context", (PyCFunction) create_compression_context,
-    METH_VARARGS | METH_KEYWORDS, create_compression_context__doc
+    METH_NOARGS, create_compression_context__doc
   },
   {
     "compress", (PyCFunction) compress,


### PR DESCRIPTION
Not a big deal, but it's more typo-proof.