### PR TITLE
Allow zero length data to be passed to block compress

### DIFF
--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -253,7 +253,7 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
       source_size -= hdr_size;
     }
 
-  if (dest_size <= 0 || dest_size > PY_SSIZE_T_MAX)
+  if (dest_size < 0 || dest_size > PY_SSIZE_T_MAX)
     {
       PyErr_Format (PyExc_ValueError, "Invalid size in header: 0x%zu",
                     dest_size);

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -121,11 +121,6 @@ compress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
       return NULL;
     }
 
-  if (source_size <= 0) {
-    PyErr_Format(PyExc_ValueError, "Input source data size invalid: %d bytes", source_size);
-    return NULL;
-  }
-
   if (!strncmp (mode, "default", sizeof ("default")))
     {
       comp = DEFAULT;

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -8,6 +8,10 @@ import os
 
 class TestLZ4Block(unittest.TestCase):
 
+    def test_empty_string(self):
+      DATA = b''
+      self.assertEqual(DATA, lz4.block.decompress(lz4.block.compress(DATA)))
+
     def test_random(self):
       DATA = os.urandom(128 * 1024)  # Read 128kb
       self.assertEqual(DATA, lz4.block.decompress(lz4.block.compress(DATA)))


### PR DESCRIPTION
This fixes #27. For the block package, data with zero length can be passed to compress, and decompress can handle a zero length uncompressed size.