### PR TITLE
Allow bytearray arguments, and return bytearrays for block functions on Python 3

### DIFF
--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -214,6 +214,16 @@ if sys.version_info < (2, 7):
     # Poor-man unittest.TestCase.skip for Python 2.6
     del TestLZ4BlockModern
 
+class TestLZ4BlockPy3ByteArray(unittest.TestCase):
+    def test_random(self):
+      DATA = bytearray(os.urandom(128 * 1024))  # Read 128kb
+      self.assertEqual(DATA, lz4.block.decompress(lz4.block.compress(DATA)))
+
+
+if sys.version_info < (3, 3):
+    # Poor-man unittest.TestCase.skip for Python < 3.3
+    del TestLZ4BlockPy3ByteArray
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
This change allows, on Python 3, a bytearray or bytes (string) to be passed in to the block compress and decompress function. This does not affect Python 2, which does not have a bytearray type.