### PR TITLE
 Properly use pkg-config to configure liblz4 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,14 @@ LZ4_VERSION = "1.7.4.2"
 def pkgconfig_cmd(cmd, libname):
     try:
         pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
-        try:
-            return subprocess.check_output([pkg_config_exe, cmd, libname]).decode('utf-8')
-        except subprocess.CalledProcessError:
+        # poor-man's check_output (for Python 2.6 compat)
+        p = subprocess.Popen([pkg_config_exe, cmd, libname], stdout=subprocess.PIPE)
+        stdout, _ = p.communicate()
+        res = p.wait() # communicate already waits for us so this shouldn't block
+        if res != 0:
+            # pkg-config failed
             return None
+        return stdout.decode('utf-8')
     except OSError:
         # pkg-config not present
         return None

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,6 @@ from distutils import ccompiler
 LZ4_VERSION = "1.7.4.2"
 
 def pkgconfig_cmd(cmd, libname):
-    # Check to see if we have a library called'libname' installed on the
-    # system. This uses pkg-config to check for existence of the library, and
-    # returns True if it's found, False otherwise. If pkg-config isn't found,
-    # Flase is returned.
     try:
         pkg_config_exe = os.environ.get('PKG_CONFIG', None) or 'pkg-config'
         try:
@@ -23,16 +19,21 @@ def pkgconfig_cmd(cmd, libname):
             return None
     except OSError:
         # pkg-config not present
-        return False
+        return None
 
 def library_is_installed(libname):
+    ''' Check to see if we have a library called 'libname' installed.
+    
+    This uses pkg-config to check for existence of the library, and
+    returns True if it's found, False otherwise. If pkg-config isn't found,
+    False is returned. '''
     return pkgconfig_cmd('--exists', libname) is not None
 
 def get_cflags(libname):
-    return pkgconfig_cmd('--cflags', libname).split() # Note! This breaks if there are spaces in the cmd
+    return pkgconfig_cmd('--cflags', libname).split()
 
 def get_ldflags(libname):
-    return pkgconfig_cmd('--libs', libname).split() # Note! This breaks if there are spaces in the cmd
+    return pkgconfig_cmd('--libs', libname).split()
 
 # Check to see if we have a lz4 library installed on the system and
 # use it if so. If not, we'll use the bundled library.


### PR DESCRIPTION
With `lz4` installed via MacPorts on macOS, python-lz4 fails to build because it doesn't add the MacPorts include path or library path. This change parses pkg-config output to bring the proper flags into play.

Tested with Python 2.7 and 3.6 on macOS 10.12.