### PR TITLE
Allow setuptools to install pkgconfig via setup_requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ python:
   - 3.4
   - 3.5
   - 3.6
-install: pip install tox pkgconfig
+install: pip install tox
 script: tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,9 +59,6 @@ install:
   # We need wheel installed to build wheels, and this isn't pulled in by setup.py
   - "build.cmd python -m pip install wheel"
 
-  # We need pkgconfig installed installed to run setup.py
-  - "build.cmd python -m pip install pkgconfig"
-
   # We need tox to run tests
   - "build.cmd python -m pip install tox"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 sphinx >= 1.4.8
-pkgconfig
 tox
 pytest
 setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,27 @@ import subprocess
 import os
 import sys
 from distutils import ccompiler
-import pkgconfig
 
 LZ4_REQUIRED_VERSION = '>= 1.7.5'
 PY3C_REQUIRED_VERSION = '>= 1.0'
 
 # Check to see if we have a lz4 and py3c libraries installed on the system, and
 # of suitable versions, and use if so. If not, we'll use the bundled libraries.
+liblz4_found = False
+py3c_found = False
 try:
-    liblz4_found = pkgconfig.installed ('liblz4', LZ4_REQUIRED_VERSION)
-    py3c_found = pkgconfig.installed('py3c', PY3C_REQUIRED_VERSION)
-except EnvironmentError:
-    # Windows, no pkg-config present
-    liblz4_found = False
-    py3c_found = False
+    import pkgconfig
+except ImportError:
+    # pkgconfig is not installed. It will be installed by setup_requires.
+    pass
+else:
+    try:
+        liblz4_found = pkgconfig.installed('liblz4', LZ4_REQUIRED_VERSION)
+        py3c_found = pkgconfig.installed('py3c', PY3C_REQUIRED_VERSION)
+    except EnvironmentError:
+        # Windows, no pkg-config present
+        pass
+
 
 # Set up the extension modules. If a system wide lz4 library is found, and is
 # recent enough, we'll use that. Otherwise we'll build with the bundled one. If

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = py
 
 [testenv]
 deps=pytest
-    pkgconfig
 # setenv = PYTHONMALLOC = pymalloc
 #     PYTHONMALLOCSTATS = 'yes'
 commands=pytest tests/block/test_block.py


### PR DESCRIPTION
If pkgconfig doesn't exist when first running `setup.py`, it will be installed by `setup_requires`. Temporarily suppress the `ImportError` until it is installed.

For additional details on the `setup_requires` option, see the setuptools documentation:

https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=setup_requires#id8

Fixes #75