### PR TITLE
Move pytest-runner from setup_requires to tests_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,6 @@ setup(
     },
     setup_requires=[
         'setuptools_scm',
-        'pytest-runner',
         'pkgconfig',
     ],
     install_requires=[
@@ -150,6 +149,7 @@ setup(
     ],
     tests_require=[
         'pytest',
+        'pytest-runner',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Used for testing not for running `setup.py` so should be moved accordingly.