### PR TITLE
Dictionary support

### DIFF
--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -97,26 +97,26 @@ static int
 lz4_compress_generic (int comp, char* source, char* dest, size_t source_size, size_t dest_size,
 		      char* dict, size_t dict_size, int acceleration, int compression)
 {
-    if (comp != HIGH_COMPRESSION)
-      {
-	LZ4_stream_t lz4_state;
-	LZ4_resetStream (&lz4_state);
-	if (dict) {
-	    LZ4_loadDict (&lz4_state, dict, dict_size);
-	}
-	if (comp != FAST)
-	  {
-	    acceleration = 1;
-	  }
-	return LZ4_compress_fast_continue (&lz4_state, source, dest, source_size, dest_size, acceleration);
-      } else {
-	LZ4_streamHC_t lz4_state;
-	LZ4_resetStreamHC (&lz4_state, compression);
-	if (dict) {
-	    LZ4_loadDictHC (&lz4_state, dict, dict_size);
-	}
-	return LZ4_compress_HC_continue (&lz4_state, source, dest, source_size, dest_size);
+  if (comp != HIGH_COMPRESSION)
+    {
+      LZ4_stream_t lz4_state;
+      LZ4_resetStream (&lz4_state);
+      if (dict) {
+	  LZ4_loadDict (&lz4_state, dict, dict_size);
       }
+      if (comp != FAST)
+	{
+	  acceleration = 1;
+	}
+      return LZ4_compress_fast_continue (&lz4_state, source, dest, source_size, dest_size, acceleration);
+    } else {
+      LZ4_streamHC_t lz4_state;
+      LZ4_resetStreamHC (&lz4_state, compression);
+      if (dict) {
+	  LZ4_loadDictHC (&lz4_state, dict, dict_size);
+      }
+      return LZ4_compress_HC_continue (&lz4_state, source, dest, source_size, dest_size);
+    }
 }
 
 static PyObject *

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -95,26 +95,30 @@ typedef enum
 
 static int
 lz4_compress_generic (int comp, char* source, char* dest, size_t source_size, size_t dest_size,
-		      char* dict, size_t dict_size, int acceleration, int compression)
+                      char* dict, size_t dict_size, int acceleration, int compression)
 {
   if (comp != HIGH_COMPRESSION)
     {
       LZ4_stream_t lz4_state;
       LZ4_resetStream (&lz4_state);
-      if (dict) {
-	  LZ4_loadDict (&lz4_state, dict, dict_size);
-      }
+      if (dict)
+        {
+          LZ4_loadDict (&lz4_state, dict, dict_size);
+        }
       if (comp != FAST)
-	{
-	  acceleration = 1;
-	}
+        {
+          acceleration = 1;
+        }
       return LZ4_compress_fast_continue (&lz4_state, source, dest, source_size, dest_size, acceleration);
-    } else {
+    }
+  else
+    {
       LZ4_streamHC_t lz4_state;
       LZ4_resetStreamHC (&lz4_state, compression);
-      if (dict) {
-	  LZ4_loadDictHC (&lz4_state, dict, dict_size);
-      }
+      if (dict)
+        {
+          LZ4_loadDictHC (&lz4_state, dict, dict_size);
+        }
       return LZ4_compress_HC_continue (&lz4_state, source, dest, source_size, dest_size);
     }
 }
@@ -195,8 +199,8 @@ compress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
       PyBuffer_Release(&source);
       PyBuffer_Release(&dict);
       PyErr_Format (PyExc_ValueError,
-		    "Invalid mode argument: %s. Must be one of: standard, fast, high_compression",
-		    mode);
+                    "Invalid mode argument: %s. Must be one of: standard, fast, high_compression",
+                    mode);
       return NULL;
     }
 
@@ -230,8 +234,8 @@ compress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
     }
 
   output_size = lz4_compress_generic (comp, source.buf, dest_start, source_size,
-				      dest_size, dict.buf, dict.len, acceleration,
-				      compression);
+                                      dest_size, dict.buf, dict.len, acceleration,
+                                      compression);
 
   Py_END_ALLOW_THREADS
 
@@ -317,7 +321,7 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
       if (source_size < hdr_size)
         {
           PyBuffer_Release(&source);
-	  PyBuffer_Release(&dict);
+          PyBuffer_Release(&dict);
           PyErr_SetString (PyExc_ValueError, "Input source data size too small");
           return NULL;
         }
@@ -345,7 +349,7 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
 
   output_size =
     LZ4_decompress_safe_usingDict (source_start, dest, source_size, dest_size,
-				   dict.buf, dict.len);
+                                   dict.buf, dict.len);
 
   Py_END_ALLOW_THREADS
 

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -415,6 +415,8 @@ PyDoc_STRVAR(compress__doc,
              "    return_bytearray (bool): If ``False`` (the default) then the function\n" \
              "        will return a bytes object. If ``True``, then the function will\n" \
              "        return a bytearray object.\n\n" \
+             "    dict (str, bytes or buffer-compatible object): If specified, perform\n" \
+             "        compression using this initial dictionary.\n" \
              "Returns:\n"                                               \
              "    bytes or bytearray: Compressed data.\n");
 
@@ -433,6 +435,8 @@ PyDoc_STRVAR(decompress__doc,
              "    return_bytearray (bool): If ``False`` (the default) then the function\n" \
              "        will return a bytes object. If ``True``, then the function will\n" \
              "        return a bytearray object.\n\n" \
+             "    dict (str, bytes or buffer-compatible object): If specified, perform\n" \
+             "        decompression using this initial dictionary.\n" \
              "Returns:\n"                                               \
              "    bytes or bytearray: Decompressed data.\n");
 

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -238,7 +238,7 @@ compress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
   PyBuffer_Release(&source);
   PyBuffer_Release(&dict);
 
-  if (output_size <= 0)
+  if ((ssize_t)output_size <= 0)
     {
       PyErr_SetString (PyExc_ValueError, "Compression failed");
       PyMem_Free (dest);
@@ -352,7 +352,7 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
   PyBuffer_Release(&source);
   PyBuffer_Release(&dict);
 
-  if (output_size < 0)
+  if ((ssize_t)output_size < 0)
     {
       PyErr_Format (PyExc_ValueError, "Corrupt input at byte %zu", -output_size);
       PyMem_Free (dest);

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -384,7 +384,7 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
 
   if (output_size < 0)
     {
-      PyErr_Format (PyExc_ValueError, "Corrupt input at byte %zu", -output_size);
+      PyErr_Format (PyExc_ValueError, "Corrupt input at byte %u", -output_size);
       PyMem_Free (dest);
       return NULL;
     }
@@ -392,7 +392,7 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
     {
       /* Better to fail explicitly than to allow fishy data to pass through. */
       PyErr_Format (PyExc_ValueError,
-                    "Decompressor wrote %zu bytes, but %zu bytes expected from header",
+                    "Decompressor wrote %u bytes, but %zu bytes expected from header",
                     output_size, dest_size);
       PyMem_Free (dest);
       return NULL;

--- a/tests/block/conftest.py
+++ b/tests/block/conftest.py
@@ -81,3 +81,15 @@ def d_return_bytearray(return_bytearray):
 )
 def mode(request):
     return request.param
+
+@pytest.fixture(
+    params=[
+        None,
+        (0, 0),
+        (100, 200),
+        (0, 8 * 1024),
+        os.urandom(8 * 1024)
+    ]
+)
+def dictionary(request):
+    return request.param

--- a/tests/block/test_block.py
+++ b/tests/block/test_block.py
@@ -206,3 +206,15 @@ def test_known_decompress():
     assert(lz4.block.decompress(
         b'\xb0\xb3\x00\x00\xff\x1fExcepteur sint occaecat cupidatat non proident.\x00' + (b'\xff' * 180) + b'\x1ePident') ==
         b'Excepteur sint occaecat cupidatat non proident' * 1000)
+
+#def test_huge():
+#    if sys.maxsize > 0xffffffff:
+#        huge = b'\0' * 0x100000000
+#        with pytest.raises(OverflowError, match='Input too large for LZ4 API'):
+#            lz4.block.compress(huge)
+#        with pytest.raises(OverflowError, match='Dictionary too large for LZ4 API'):
+#            lz4.block.compress(b'', dict=huge)
+#        with pytest.raises(OverflowError, match='Input too large for LZ4 API'):
+#            lz4.block.decompress(huge)
+#        with pytest.raises(OverflowError, match='Dictionary too large for LZ4 API'):
+#            lz4.block.decompress(b'', dict=huge)

--- a/tests/block/test_block.py
+++ b/tests/block/test_block.py
@@ -181,3 +181,17 @@ def test_with_dict():
         assert lz4.block.decompress(compressed, dict=dict2) != input_data
         assert lz4.block.decompress(compressed, dict=dict1) == input_data
     assert lz4.block.decompress(lz4.block.compress(input_data), dict=dict1) == input_data
+
+def test_known_decompress():
+    assert(lz4.block.decompress(
+        b'\x00\x00\x00\x00\x00') ==
+        b'')
+    assert(lz4.block.decompress(
+        b'\x01\x00\x00\x00\x10 ') ==
+        b' ')
+    assert(lz4.block.decompress(
+        b'h\x00\x00\x00\xff\x0bLorem ipsum dolor sit amet\x1a\x006P amet') ==
+        b'Lorem ipsum dolor sit amet' * 4)
+    assert(lz4.block.decompress(
+        b'\xb0\xb3\x00\x00\xff\x1fExcepteur sint occaecat cupidatat non proident.\x00' + (b'\xff' * 180) + b'\x1ePident') ==
+        b'Excepteur sint occaecat cupidatat non proident' * 1000)

--- a/tests/block/test_block.py
+++ b/tests/block/test_block.py
@@ -123,7 +123,7 @@ def test_decompress_truncated():
         with pytest.raises(ValueError, match='Input source data size too small'):
             lz4.block.decompress(compressed[:n])
     for n in [24, 25, -2, 27, 67, 85]:
-        with pytest.raises(ValueError, match=r'Corrupt input at byte \d+'):
+        with pytest.raises(ValueError, match=r'Corrupt input at byte \d+|Decompressor wrote \d+ bytes, but \d+ bytes expected from header'):
             lz4.block.decompress(compressed[:n])
 
 


### PR DESCRIPTION
This adds support for pre-loading a dictionary prior to block compression and decompression by optionally passing in a dictionary to the respective functions.

For compression, using a dictionary requires using `LZ4_resetStream()`/`LZ4_loadDict()`/`LZ4_compress_continue()` instead of the more convenient `LZ4_compress_*() functions` . I've unified the code paths for both cases, so that the convenience methods are no longer used even if there is no dictionary to be used.

For decompression, there is a `LZ4_decompress_safe_usingDict()` variant that could be used directly.