### PR TITLE
Fix for frame.open(mode="r") objects in python 2.x

### DIFF
--- a/lz4/frame/_compression.py
+++ b/lz4/frame/_compression.py
@@ -4,6 +4,7 @@
 
 """Internal classes used by the gzip, lzma and bz2 modules"""
 
+import sys
 import io
 # Ensure super has Python 3 semantics even on Python 2
 from builtins import super
@@ -156,3 +157,13 @@ class DecompressReader(io.RawIOBase):
     def tell(self):
         """Return the current file position."""
         return self._pos
+
+
+if sys.version_info < (3, 3):
+    # memoryview.cast is added in 3.3
+    def readinto(self, b):
+        data = self.read(len(b))
+        b[:len(data)] = data
+        return len(data)
+
+    DecompressReader.readinto = readinto

--- a/tests/frame/test_frame_6.py
+++ b/tests/frame/test_frame_6.py
@@ -55,6 +55,17 @@ def test_lz4frame_open_write_read_text():
     assert data_out == data
 
 
+def test_lz4frame_open_write_read_text_iter():
+    data = u'This is a test string'
+    with lz4frame.open('testfile', mode='wt') as fp:
+        fp.write(data)
+    data_out = ''
+    with lz4frame.open('testfile', mode='rt') as fp:
+        for line in fp:
+            data_out += line
+    assert data_out == data
+
+
 def test_lz4frame_open_write_read(
         data,
         compression_level,


### PR DESCRIPTION
`memoryview` objects in older python versions do not have the `cast` method; moreover they are not even context manager objects.  I am not sure whether this is the best fix, but it works for me.  Maybe I shall add a test case?