### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,7 +1,7 @@
 Install
 =======
 
-The package is hosted on `PyPI <http://pypi.python.org/pypi/lz4>`_ and so can be
+The package is hosted on `PyPI <https://pypi.org/project/lz4/>`_ and so can be
 installed via pip::
 
   $ pip install lz4


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html