### PR TITLE
Increase memory use tolerance in test_frame_5.py

### DIFF
--- a/tests/frame/test_frame_5.py
+++ b/tests/frame/test_frame_5.py
@@ -32,7 +32,7 @@ def test_frame_decompress_mem_usage(data):
 
             if prev_snapshot:
                 stats = snapshot.compare_to(prev_snapshot, 'lineno')
-                assert stats[0].size_diff < (1024 * 4)
+                assert stats[0].size_diff < (1024 * 15)
 
             prev_snapshot = snapshot
 
@@ -56,7 +56,7 @@ def test_frame_decompress_chunk_mem_usage(data):
 
             if prev_snapshot:
                 stats = snapshot.compare_to(prev_snapshot, 'lineno')
-                assert stats[0].size_diff < (1024 * 10)
+                assert stats[0].size_diff < (1024 * 15)
 
             prev_snapshot = snapshot
 
@@ -79,7 +79,7 @@ def test_frame_open_decompress_mem_usage(data):
 
             if prev_snapshot:
                 stats = snapshot.compare_to(prev_snapshot, 'lineno')
-                assert stats[0].size_diff < (1024 * 10)
+                assert stats[0].size_diff < (1024 * 15)
 
             prev_snapshot = snapshot
 


### PR DESCRIPTION
The original values allowed the tests to succeed when each
test file was run under pytest individually (e.g. via tox),
but when run using `python setup.py test` they would fail.
This is because the latter invocation collects all tests
together, increasing the python process memory usage, and
increasing the variance of memory usage.