### PR TITLE
Gracefully handle old versions of liblz4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,21 @@ except ImportError:
     # pkgconfig is not installed. It will be installed by setup_requires.
     pass
 else:
-    try:
-        liblz4_found = pkgconfig.installed('liblz4', LZ4_REQUIRED_VERSION)
-        py3c_found = pkgconfig.installed('py3c', PY3C_REQUIRED_VERSION)
-    except EnvironmentError:
-        # Windows, no pkg-config present
-        pass
+    def pkgconfig_installed(lib, required_version, default):
+        installed = default
+        try:
+            installed = pkgconfig.installed(lib, required_version)
+        except EnvironmentError:
+            # Windows, no pkg-config present
+            pass
+        except ValueError:
+            # pkgconfig was unable to determine if
+            # required version of liblz4 is available
+            # Bundled version of liblz4 will be used
+            pass
+        return installed
+    liblz4_found = pkgconfig_installed('liblz4', LZ4_REQUIRED_VERSION, default=False)
+    py3c_found = pkgconfig_installed('py3c', PY3C_REQUIRED_VERSION, default=False)
 
 
 # Set up the extension modules. If a system wide lz4 library is found, and is


### PR DESCRIPTION
Fixes: #136
 * Handles `ValueError` from `pkgconfig` module for older versions of liblz4 that don't follow conventional X.Y.Z versioning schema.
 * Falls back to using bundled version of liblz4

I am not sure how (or if it even makes sense) to print the error so it shows up during `pip install`. 
`logging` is unlikely to be initialized at that time, I could add `print(...,file=sys.stderr)` or even use the `warnings` module if you prefer.