### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,7 +60,7 @@ install:
   # We need wheel installed to build wheels, and this isn't pulled in by setup.py
   - "build.cmd python -m pip install wheel"
 
-  # We need twine installed to push wheels to PyPi
+  # We need twine installed to push wheels to PyPI
   - "build.cmd python -m pip install twine"
 
   # We need tox to run tests


### PR DESCRIPTION
As spelled on https://pypi.org/.