### PR TITLE
Simplify tox.ini configuration with the extras option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist = py
+minversion = 2.4.0
 
 [testenv]
-deps=.[tests]
+extras = tests
 passenv = *
 # setenv = PYTHONMALLOC = pymalloc
 #     PYTHONMALLOCSTATS = 'yes'


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/config.html#conf-extras

> A list of “extras” to be installed with the sdist or develop install.
> For example, extras = testing is equivalent to [testing] in a pip
> install command.