### PR TITLE
Integrate cibuildwheel into travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-cache: pip
+
 matrix:
   include:
     - name: linux-py27
@@ -115,7 +115,7 @@ script:
   - flake8 --ignore=E501 setup.py
   - ${PIP} install .
   - ${PIP} install .[tests]
-  - tox
+  - pytest
   - make -C docs doctest html
   - cibuildwheel --output-dir dist
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-language: python
-
 matrix:
   include:
     - name: linux-py27
+      language: python
       python: 2.7
       sudo: required
       services:
@@ -11,6 +10,7 @@ matrix:
         - PIP=pip
         - CIBW_BUILD=cp27-*
     - name: linux-py34
+      language: python
       python: 3.4
       sudo: required
       services:
@@ -19,6 +19,7 @@ matrix:
         - PIP=pip
         - CIBW_BUILD=cp34-*
     - name: linux-py35
+      language: python
       python: 3.5
       sudo: required
       services:
@@ -27,6 +28,7 @@ matrix:
         - PIP=pip3
         - CIBW_BUILD=cp35-*
     - name: linux-py36
+      language: python
       python: 3.6
       sudo: required
       services:
@@ -35,6 +37,7 @@ matrix:
         - PIP=pip3
         - CIBW_BUILD=cp36-*
     - name: linux-py37
+      language: python
       python: 3.7
       dist: xenial
       sudo: required
@@ -105,11 +108,10 @@ matrix:
         - cibuildwheel --output-dir dist
 install:
   - ${PIP} install -U pip
-  - ${PIP} install tox
   - ${PIP} install -r docs/requirements.txt
   - ${PIP} install cibuildwheel==0.10.0
-script:
   - ${PIP} install .[flake8]
+script:
   - flake8 --ignore=E501 lz4
   - flake8 --ignore=E501 tests
   - flake8 --ignore=E501 setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,123 @@
 language: python
-python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
+cache: pip
+matrix:
+  include:
+    - name: linux-py27
+      python: 2.7
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip
+        - CIBW_BUILD=cp27-*
+    - name: linux-py34
+      python: 3.4
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip
+        - CIBW_BUILD=cp34-*
+    - name: linux-py35
+      python: 3.5
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip3
+        - CIBW_BUILD=cp35-*
+    - name: linux-py36
+      python: 3.6
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip3
+        - CIBW_BUILD=cp36-*
+    - name: linux-py37
+      python: 3.7
+      dist: xenial
+      sudo: required
+      services:
+        - docker
+      env:
+        - PIP=pip3
+        - CIBW_BUILD=cp37-*
+    - name: osx-py27
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp27-*
+        - CIBW_TEST_COMMAND="pytest {project}/tests"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install .; $PIP install .[tests]"
+      install:
+        - ${PIP} install cibuildwheel==0.10.0
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py34
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp34-*
+        - CIBW_TEST_COMMAND="pytest {project}/tests"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install .; $PIP install .[tests]"
+      install:
+        - ${PIP} install cibuildwheel==0.10.0
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py35
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp35-*
+        - CIBW_TEST_COMMAND="pytest {project}/tests"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install .; $PIP install .[tests]"
+      install:
+        - ${PIP} install cibuildwheel==0.10.0
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py36
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp36-*
+        - CIBW_TEST_COMMAND="pytest {project}/tests"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install .; $PIP install .[tests]"
+      install:
+        - ${PIP} install cibuildwheel==0.10.0
+      script:
+        - cibuildwheel --output-dir dist
+    - name: osx-py37
+      os: osx
+      language: generic
+      env:
+        - PIP=pip2
+        - CIBW_BUILD=cp37-*
+        - CIBW_TEST_COMMAND="pytest {project}/tests"
+        - CIBW_BEFORE_BUILD="${PIP} install -U pip; ${PIP} install .; $PIP install .[tests]"
+      install:
+        - ${PIP} install cibuildwheel==0.10.0
+      script:
+        - cibuildwheel --output-dir dist
 install:
-  - pip install -U pip
-  - pip install tox
-  - pip install -r docs/requirements.txt
+  - ${PIP} install -U pip
+  - ${PIP} install tox
+  - ${PIP} install -r docs/requirements.txt
+  - ${PIP} install cibuildwheel==0.10.0
 script:
-  - pip install .[flake8]
+  - ${PIP} install .[flake8]
   - flake8 --ignore=E501 lz4
   - flake8 --ignore=E501 tests
   - flake8 --ignore=E501 setup.py
+  - ${PIP} install .
+  - ${PIP} install .[tests]
   - tox
-  - pip install .
-  - pip install .[tests]
   - make -C docs doctest html
+  - cibuildwheel --output-dir dist
 deploy:
   - provider: pypi
     # server: https://test.pypi.org/legacy/
@@ -27,4 +128,4 @@ deploy:
     on:
       branch: master
       tags: true
-      python: '3.6'
+

--- a/setup.py
+++ b/setup.py
@@ -141,8 +141,10 @@ if sys.version_info < (3, 0):
 # refer to it for the tests_require and the extras_require arguments
 # to setup below. The latter enables us to use pip install .[tests] to
 # install testing dependencies.
+# Note: pytest 3.3.0 contains a bug with null bytes in parameter IDs:
+# https://github.com/pytest-dev/pytest/issues/2957
 tests_require = [
-    'pytest',
+    'pytest!=3.3.0',
     'psutil',
 ],
 

--- a/tests/block/conftest.py
+++ b/tests/block/conftest.py
@@ -92,13 +92,19 @@ def mode(request):
     return request.param
 
 
+dictionary = [
+    None,
+    (0, 0),
+    (100, 200),
+    (0, 8 * 1024),
+    os.urandom(8 * 1024)
+]
+
+
 @pytest.fixture(
-    params=[
-        None,
-        (0, 0),
-        (100, 200),
-        (0, 8 * 1024),
-        os.urandom(8 * 1024)
+    params=dictionary,
+    ids=[
+        'dictionary' + str(i) for i in range(len(dictionary))
     ]
 )
 def dictionary(request):


### PR DESCRIPTION
This enables building of linux and osx wheels on the travis CI infra.