### PR TITLE
setup.py: Handle multiple args from pkgconfig

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,8 @@ if compiler == 'msvc':
     extra_compile_args = ['/Ot', '/Wall', '/wd4711', '/wd4820']
 elif compiler in ('unix', 'mingw32'):
     if liblz4_found:
-        extra_link_args.append(pkgconfig_libs('liblz4'))
-        if pkgconfig_cflags('liblz4'):
-            extra_compile_args.append(pkgconfig_cflags('liblz4'))
+        extra_link_args.extend(pkgconfig_libs('liblz4').split())
+        extra_compile_args.extend(pkgconfig_cflags('liblz4').split())
     else:
         extra_compile_args = [
             '-O3',


### PR DESCRIPTION
The pkgconfig_cflags and pkgconfig_libs functions return the arguments
to add to the compiler and linker command line as a space-separated
string. Handle this correctly by splitting the string apart on spaces
and appending each individual argument to the respective command line.

Fixes #200. Again I've taken the more conservative approach, and made the smallest code change that would fix the bug.