### PR TITLE
Remove unnecessary memory clears during stream buffer allocation and release

### DIFF
--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -524,9 +524,6 @@ double_buffer_release_resources (stream_context_t * context)
 
   if (context->strategy.data.double_buffer.buf != NULL)
     {
-      memset (context->strategy.data.double_buffer.buf,
-              0x0,
-              context->strategy.data.double_buffer.page_size * DOUBLE_BUFFER_PAGE_COUNT);
       PyMem_Free (context->strategy.data.double_buffer.buf);
     }
   context->strategy.data.double_buffer.buf = NULL;
@@ -550,10 +547,6 @@ double_buffer_reserve_resources (stream_context_t * context, unsigned int buffer
       status = -1;
       goto exit_now;
     }
-
-  memset (context->strategy.data.double_buffer.buf,
-          0x0,
-          context->strategy.data.double_buffer.page_size * DOUBLE_BUFFER_PAGE_COUNT);
 
   for (i = DOUBLE_BUFFER_INDEX_MIN;
        i < (DOUBLE_BUFFER_INDEX_MIN + DOUBLE_BUFFER_PAGE_COUNT);
@@ -738,14 +731,12 @@ destroy_context (stream_context_t * context)
   /* Release output buffer */
   if (context->output.buf != NULL)
     {
-      memset (context->output.buf, 0x0, context->output.len);
       PyMem_Free (context->output.buf);
     }
   context->output.buf = NULL;
   context->output.len = 0;
 
   /* Release python memory */
-  memset (context, 0x0, sizeof (stream_context_t));
   PyMem_Free (context);
 }
 


### PR DESCRIPTION
This removes calls to `memset()` the buffers used by the stream library just after they are allocated and just before they are released. The buffers do not need to be cleared or the code to operate correctly because the code does not read from the buffers before they are written to.

Clearing the buffers forces the operating system to actually allocate the memory, or load it from disk, and make it available to the application. This wastes time during allocation if some parts of the buffers are never used and wastes time during release because the buffers will never be touched again.

This change improves #209 considerably (but is not a complete fix). Time for the 1GiB and LZ4_MAX_INPUT_SIZE test cases in stream test 3 (`pytest tests/stream/test_stream_3.py`) is reduced, on my machine, from 3 hours and 30 minutes to 3.15 seconds. The time for other tests does not increase. Total time for `tox tests` on my machine is reduced from 4 hours and 12 minutes to 45 minutes. Peak memory usage is also reduced from approximately 4 gigabytes to approximately 25 megabytes.