### PR TITLE
Improve stream test speed and CI coverage

### DIFF
--- a/tests/stream/test_stream_0.py
+++ b/tests/stream/test_stream_0.py
@@ -1,27 +1,8 @@
 import lz4.stream
 import sys
 import pytest
-import gc
-import os
 if sys.version_info <= (3, 2):
     import struct
-
-
-def run_gc(func):
-    if os.environ.get('TRAVIS') is not None or os.environ.get('APPVEYOR') is not None:
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-    else:
-        def wrapper(*args, **kwargs):
-            gc.collect()
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                gc.collect()
-            return result
-
-    wrapper.__name__ = func.__name__
-    return wrapper
 
 
 def get_stored_size(buff, block_length_size):
@@ -45,7 +26,6 @@ def get_stored_size(buff, block_length_size):
         return struct.unpack('<' + fmt[block_length_size], b[:block_length_size])[0]
 
 
-@run_gc
 def roundtrip(x, c_kwargs, d_kwargs, dictionary):
     if dictionary:
         if isinstance(dictionary, tuple):

--- a/tests/stream/test_stream_1.py
+++ b/tests/stream/test_stream_1.py
@@ -3,7 +3,6 @@ import pytest
 import sys
 import os
 import psutil
-import gc
 
 
 if sys.version_info < (3, ):
@@ -44,40 +43,6 @@ _4GB = 0x100000000  # 4GB
 # fragile.
 
 
-def run_gc(func):
-    if os.environ.get('TRAVIS') is not None or os.environ.get('APPVEYOR') is not None:
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-    else:
-        def wrapper(*args, **kwargs):
-            gc.collect()
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                gc.collect()
-            return result
-
-    wrapper.__name__ = func.__name__
-    return wrapper
-
-
-def run_gc_param_store_comp_size(func):
-    if os.environ.get('TRAVIS') is not None:
-        def wrapper(store_comp_size, *args, **kwargs):
-            return func(store_comp_size, *args, **kwargs)
-    else:
-        def wrapper(store_comp_size, *args, **kwargs):
-            gc.collect()
-            try:
-                result = func(store_comp_size, *args, **kwargs)
-            finally:
-                gc.collect()
-            return result
-
-    wrapper.__name__ = func.__name__
-    return wrapper
-
-
 def compress(x, c_kwargs, return_block_offset=False, check_block_type=False):
     o = [0, ]
     if c_kwargs.get('return_bytearray', False):
@@ -116,7 +81,6 @@ def decompress(x, d_kwargs, check_chunk_type=False):
     return d
 
 
-@run_gc
 def test_invalid_config_c_1():
     c_kwargs = {}
     c_kwargs['strategy'] = "ring_buffer"
@@ -126,7 +90,6 @@ def test_invalid_config_c_1():
         lz4.stream.LZ4StreamCompressor(**c_kwargs)
 
 
-@run_gc
 def test_invalid_config_d_1():
     d_kwargs = {}
     d_kwargs['strategy'] = "ring_buffer"
@@ -136,7 +99,6 @@ def test_invalid_config_d_1():
         lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
 
-@run_gc
 def test_invalid_config_c_2():
     c_kwargs = {}
     c_kwargs['strategy'] = "foo"
@@ -146,7 +108,6 @@ def test_invalid_config_c_2():
         lz4.stream.LZ4StreamCompressor(**c_kwargs)
 
 
-@run_gc
 def test_invalid_config_d_2():
     d_kwargs = {}
     d_kwargs['strategy'] = "foo"
@@ -156,7 +117,6 @@ def test_invalid_config_d_2():
         lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
 
-@run_gc_param_store_comp_size
 def test_invalid_config_c_3(store_comp_size):
     c_kwargs = {}
     c_kwargs['strategy'] = "double_buffer"
@@ -167,7 +127,6 @@ def test_invalid_config_c_3(store_comp_size):
         lz4.stream.LZ4StreamCompressor(**c_kwargs)
 
 
-@run_gc_param_store_comp_size
 def test_invalid_config_d_3(store_comp_size):
     d_kwargs = {}
     d_kwargs['strategy'] = "double_buffer"
@@ -178,7 +137,6 @@ def test_invalid_config_d_3(store_comp_size):
         lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
 
-@run_gc_param_store_comp_size
 def test_invalid_config_c_4(store_comp_size):
     c_kwargs = {}
     c_kwargs['strategy'] = "double_buffer"
@@ -204,7 +162,6 @@ def test_invalid_config_c_4(store_comp_size):
         lz4.stream.LZ4StreamCompressor(**c_kwargs)
 
 
-@run_gc_param_store_comp_size
 def test_invalid_config_d_4(store_comp_size):
     d_kwargs = {}
     d_kwargs['strategy'] = "double_buffer"
@@ -233,7 +190,6 @@ def test_invalid_config_d_4(store_comp_size):
     lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
 
-@run_gc
 def test_invalid_config_c_5():
     c_kwargs = {}
     c_kwargs['strategy'] = "double_buffer"
@@ -265,7 +221,6 @@ def test_invalid_config_c_5():
         lz4.stream.LZ4StreamCompressor(**c_kwargs)
 
 
-@run_gc
 def test_invalid_config_d_5():
     d_kwargs = {}
     d_kwargs['strategy'] = "double_buffer"
@@ -322,7 +277,6 @@ def test_invalid_config_d_5():
     lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
 
-@run_gc
 def test_decompress_corrupted_input_1():
     c_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -338,7 +292,6 @@ def test_decompress_corrupted_input_1():
         decompress(data[4:], d_kwargs)
 
 
-@run_gc
 def test_decompress_corrupted_input_2():
     c_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -363,7 +316,6 @@ def test_decompress_corrupted_input_2():
         decompress(data, d_kwargs)
 
 
-@run_gc
 def test_decompress_corrupted_input_3():
     c_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -393,7 +345,6 @@ def test_decompress_corrupted_input_3():
         decompress(data, d_kwargs)
 
 
-@run_gc
 def test_decompress_corrupted_input_4():
     c_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -425,7 +376,6 @@ def test_decompress_corrupted_input_4():
         decompress(data, d_kwargs)
 
 
-@run_gc
 def test_decompress_truncated():
     c_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -458,7 +408,6 @@ def test_decompress_truncated():
 # we will keep them for now
 
 
-@run_gc
 def test_decompress_with_trailer():
     c_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -485,7 +434,6 @@ def test_decompress_with_trailer():
             decompress(comp + b'\x00' * n, d_kwargs)
 
 
-@run_gc
 def test_unicode():
     if sys.version_info < (3,):
         return  # skip
@@ -505,7 +453,6 @@ def test_unicode():
 # for now
 
 
-@run_gc
 def test_return_bytearray():
     if sys.version_info < (3,):
         return  # skip
@@ -527,7 +474,6 @@ def test_return_bytearray():
     assert bytes(b) == data
 
 
-@run_gc
 def test_memoryview():
     if sys.version_info < (2, 7):
         return  # skip
@@ -543,7 +489,6 @@ def test_memoryview():
     assert decompress(memoryview(compressed), d_kwargs) == data
 
 
-@run_gc
 def test_with_dict_none():
     kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -586,7 +531,6 @@ def test_with_dict_none():
         assert decompress(compress(input_data, c_kwargs), d_kwargs) == input_data
 
 
-@run_gc
 def test_with_dict():
     kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -625,7 +569,6 @@ def test_with_dict():
     assert decompress(compress(input_data, c_kwargs), d_kwargs) == input_data
 
 
-@run_gc
 def test_known_decompress_1():
     d_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -640,7 +583,6 @@ def test_known_decompress_1():
     assert decompress(input, d_kwargs) == output
 
 
-@run_gc
 def test_known_decompress_2():
     d_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -649,7 +591,6 @@ def test_known_decompress_2():
     assert decompress(input, d_kwargs) == output
 
 
-@run_gc
 def test_known_decompress_3():
     d_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 
@@ -659,7 +600,6 @@ def test_known_decompress_3():
     assert decompress(input, d_kwargs) == output
 
 
-@run_gc
 def test_known_decompress_4():
     d_kwargs = {'strategy': "double_buffer", 'buffer_size': 128, 'store_comp_size': 4}
 

--- a/tests/stream/test_stream_2.py
+++ b/tests/stream/test_stream_2.py
@@ -3,24 +3,6 @@ import sys
 import lz4.stream
 import psutil
 import os
-import gc
-
-
-def run_gc(func):
-    if os.environ.get('TRAVIS') is not None or os.environ.get('APPVEYOR') is not None:
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-    else:
-        def wrapper(*args, **kwargs):
-            gc.collect()
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                gc.collect()
-            return result
-
-    wrapper.__name__ = func.__name__
-    return wrapper
 
 
 # This test requires allocating a big lump of memory. In order to
@@ -60,7 +42,6 @@ else:
     psutil.virtual_memory().available < _4GB or huge is None,
     reason='Insufficient system memory for this test'
 )
-@run_gc
 def test_huge_1():
     data = b''
     kwargs = {
@@ -100,7 +81,6 @@ def test_huge_1():
     psutil.virtual_memory().available < _4GB or huge is None,
     reason='Insufficient system memory for this test'
 )
-@run_gc
 def test_huge_2():
     data = huge
     kwargs = {
@@ -141,7 +121,6 @@ def test_huge_2():
     psutil.virtual_memory().available < _4GB or huge is None,
     reason='Insufficient system memory for this test'
 )
-@run_gc
 def test_huge_3():
     data = huge
     kwargs = {

--- a/tests/stream/test_stream_3.py
+++ b/tests/stream/test_stream_3.py
@@ -3,29 +3,11 @@ import pytest
 import sys
 import os
 import psutil
-import gc
 
 
 _1KB = 1024
 _1MB = _1KB * 1024
 _1GB = _1MB * 1024
-
-
-def run_gc_param_data_buffer_size(func):
-    if os.environ.get('TRAVIS') is not None or os.environ.get('APPVEYOR') is not None:
-        def wrapper(data, buffer_size, *args, **kwargs):
-            return func(data, buffer_size, *args, **kwargs)
-    else:
-        def wrapper(data, buffer_size, *args, **kwargs):
-            gc.collect()
-            try:
-                result = func(data, buffer_size, *args, **kwargs)
-            finally:
-                gc.collect()
-            return result
-
-    wrapper.__name__ = func.__name__
-    return wrapper
 
 
 def compress(x, c_kwargs):
@@ -91,7 +73,6 @@ def data(request):
     return request.param
 
 
-@run_gc_param_data_buffer_size
 def test_block_decompress_mem_usage(data, buffer_size):
     kwargs = {
         'strategy': "double_buffer",

--- a/tests/stream/test_stream_3.py
+++ b/tests/stream/test_stream_3.py
@@ -1,8 +1,6 @@
 import lz4.stream
 import pytest
 import sys
-import os
-import psutil
 
 
 _1KB = 1024
@@ -80,20 +78,8 @@ def test_block_decompress_mem_usage(data, buffer_size):
         'store_comp_size': 4,
     }
 
-    if os.environ.get('TRAVIS') is not None:
-        pytest.skip('Skipping test on Travis due to insufficient memory')
-
-    if os.environ.get('APPVEYOR') is not None:
-        pytest.skip('Skipping test on AppVeyor due to insufficient resources')
-
     if sys.maxsize < 0xffffffff:
         pytest.skip('Py_ssize_t too small for this test')
-
-    if psutil.virtual_memory().available < 3 * kwargs['buffer_size']:
-        # The internal LZ4 context will request at least 3 times buffer_size
-        # as memory (2 buffer_size for the double-buffer, and 1.x buffer_size
-        # for the output buffer)
-        pytest.skip('Insufficient system memory for this test')
 
     tracemalloc = pytest.importorskip('tracemalloc')
 

--- a/tests/stream/test_stream_3.py
+++ b/tests/stream/test_stream_3.py
@@ -29,31 +29,31 @@ def run_gc_param_data_buffer_size(func):
 
 
 def compress(x, c_kwargs):
-    if c_kwargs.get('return_bytearray', False):
-        c = bytearray()
-    else:
-        c = bytes()
+    c = []
     with lz4.stream.LZ4StreamCompressor(**c_kwargs) as proc:
         for start in range(0, len(x), c_kwargs['buffer_size']):
             chunk = x[start:start + c_kwargs['buffer_size']]
             block = proc.compress(chunk)
-            c += block
-    return c
+            c.append(block)
+    if c_kwargs.get('return_bytearray', False):
+        return bytearray().join(c)
+    else:
+        return bytes().join(c)
 
 
 def decompress(x, d_kwargs):
-    if d_kwargs.get('return_bytearray', False):
-        d = bytearray()
-    else:
-        d = bytes()
+    d = []
     with lz4.stream.LZ4StreamDecompressor(**d_kwargs) as proc:
         start = 0
         while start < len(x):
             block = proc.get_block(x[start:])
             chunk = proc.decompress(block)
-            d += chunk
+            d.append(chunk)
             start += d_kwargs['store_comp_size'] + len(block)
-    return d
+    if d_kwargs.get('return_bytearray', False):
+        return bytearray().join(d)
+    else:
+        return bytes().join(d)
 
 
 test_buffer_size = sorted(

--- a/tests/stream/test_stream_4.py
+++ b/tests/stream/test_stream_4.py
@@ -1,25 +1,6 @@
 import lz4.stream
 import pytest
 import sys
-import os
-import gc
-
-
-def run_gc(func):
-    if os.environ.get('TRAVIS') is not None or os.environ.get('APPVEYOR') is not None:
-        def wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-    else:
-        def wrapper(*args, **kwargs):
-            gc.collect()
-            try:
-                result = func(*args, **kwargs)
-            finally:
-                gc.collect()
-            return result
-
-    wrapper.__name__ = func.__name__
-    return wrapper
 
 
 if sys.version_info < (3, ):
@@ -47,7 +28,6 @@ else:
 # Out-of-band block size record tests
 
 
-@run_gc
 def test_round_trip():
     data = b"2099023098234882923049823094823094898239230982349081231290381209380981203981209381238901283098908123109238098123" * 24
     kwargs = {'strategy': "double_buffer", 'buffer_size': 256, 'store_comp_size': 4}
@@ -127,7 +107,6 @@ def test_round_trip():
     assert (data == oob_dstream), "Decompressed streams mismatch"
 
 
-@run_gc
 def test_invalid_usage():
     data = b"2099023098234882923049823094823094898239230982349081231290381209380981203981209381238901283098908123109238098123" * 24
     kwargs = {'strategy': "double_buffer", 'buffer_size': 256, 'store_comp_size': 0}


### PR DESCRIPTION
NOTE: this PR includes the changes from #210 (and times are measured relative to it). Once that is merged, I will rebase this one and remove the draft status.

The first change avoids the quadradic append cost when concatenating chunks during compression and decompression in `tests/stream/test_stream_3.py`. On my machine, this reduces the time taken by this test from 4 minutes and 17 seconds to 47 seconds.

The second change removes calls to the garbage collector during the tests in `tests/stream`. On my machine, this reduces time taken by these tests from 10 minutes and 58 seconds to 2 minutes and 44 seconds. Peak memory usage is 4.1GiB both before and after the change. Average memory usage is also 4.1GiB both before and after the change (it seems all the memory is allocated at the beginning). The garbage collector is not called in CI environments anyway.

The third change removes some checks for resources and free memory as the buffer memory is now no longer actually allocated, allowing more of the stream tests to run in CI environments.

Together with #210, this PR fixes #209 by reducing the total test time (`/usr/bin/time --verbose tox tests`), on my machine, from 4 hours and 12 minutes to 8 minutes and 25 seconds. Peak memory usage is 8.2GiB both before and after the changes. 

In a CI environment (emulated on my machine by setting the `TRAVIS` environment variable, as in `TRAVIS=travis /usr/bin/time --verbose tox tests`), total test time increases from 7 minutes and 12 seconds to 8 minutes and 24 seconds. Additionally, peak memory usage increases from 310MiB to 408MiB. If these increases are not desired, not merging the third change will avoid them.