### PR TITLE
Add readall to LZ4FrameFile and use it on python 3.10

### DIFF
--- a/lz4/frame/__init__.py
+++ b/lz4/frame/__init__.py
@@ -617,6 +617,17 @@ class LZ4FrameFile(_compression.BaseStream):
         # returns at least one byte (except at EOF)
         return self._buffer.peek(size)
 
+    def readall(self):
+        chunks = bytearray()
+
+        while True:
+            data = self.read(io.DEFAULT_BUFFER_SIZE)
+            chunks += data
+            if not data:
+                break
+
+        return bytes(chunks)
+
     def read(self, size=-1):
         """Read up to ``size`` uncompressed bytes from the file.
 
@@ -632,6 +643,9 @@ class LZ4FrameFile(_compression.BaseStream):
 
         """
         self._check_can_read()
+
+        if size < 0 and sys.version_info >= (3, 10):
+            return self.readall()
         return self._buffer.read(size)
 
     def read1(self, size=-1):


### PR DESCRIPTION
Closes #219

On 3.10, when size is < 0, use a readall method that reads things in chunks (adapted from [here](https://github.com/python/cpython/blob/225caf78d1096355b7ab072898e28f7ea500ab0f/Lib/_pyio.py#L646)).

