### PR TITLE
Pass source_size kwarg through from frame.open to LZ4FrameFile instance

### DIFF
--- a/lz4/frame/__init__.py
+++ b/lz4/frame/__init__.py
@@ -829,6 +829,7 @@ def open(filename, mode="rb",
         block_checksum=block_checksum,
         auto_flush=auto_flush,
         return_bytearray=return_bytearray,
+        source_size=source_size,
     )
 
     if 't' in mode:


### PR DESCRIPTION
When ```frame.open``` instantiates an LZ4FrameFile object, it was not passing the ```source_size``` kwarg to it. Now it does! Closes #224.