### PR TITLE
`LZ4FrameFile.write()`/`LZ4FrameDecompressor.decompress()` handle buffer protocol correctly

### DIFF
--- a/tests/frame/test_frame_9.py
+++ b/tests/frame/test_frame_9.py
@@ -1,5 +1,10 @@
+import array
 import os
+import io
+import pickle
+import sys
 import lz4.frame
+import pytest
 
 
 def test_issue_172_1():
@@ -42,3 +47,25 @@ def test_issue_172_3():
         data = fp.read(16 * 1024 - 1)
         assert len(data) == 9 * 1024
         assert data == input_data
+
+
+def test_issue_227_1():
+    q = array.array('Q', [1, 2, 3, 4, 5])
+    LENGTH = len(q) * q.itemsize
+
+    with lz4.frame.open(io.BytesIO(), 'w') as f:
+        assert f.write(q) == LENGTH
+        assert f.tell() == LENGTH
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="PickleBuffer only availiable in Python 3.8 or greater"
+)
+def test_issue_227_2():
+    q = array.array('Q', [1, 2, 3, 4, 5])
+
+    c = lz4.frame.compress(q)
+    d = lz4.frame.LZ4FrameDecompressor().decompress(pickle.PickleBuffer(c))
+
+    assert memoryview(q).tobytes() == d


### PR DESCRIPTION
Closes #227 