### PR TITLE
Added aarch64 wheels

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest] 
         cibw_build: [cp37-*, cp38-*, cp39-*, cp310-*]
-        cibw_archs_linux: [auto, ] # aarch64]
+        cibw_archs_linux: [auto, aarch64]
         cibw_skip: ["cp*-musllinux*", ]
     steps:
       - name: Check out repository


### PR DESCRIPTION
I tested the aarch64 wheel option and it seemed to work. While the tests took a while to complete, the aarch64 wheels were built successfully: https://github.com/squaresmile/python-lz4/runs/5810901633?check_suite_focus=true