### PR TITLE
Fix memory leak in lz4.frame.decompress

### DIFF
--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -1068,6 +1068,7 @@ __decompress(LZ4F_dctx * context, char * source, size_t source_size,
           PyErr_Format (PyExc_RuntimeError,
                         "LZ4F_decompress failed with code: %s",
                         LZ4F_getErrorName (result));
+          PyMem_Free (destination);
           return NULL;
         }
 


### PR DESCRIPTION
Fixes #247 

Sample logs from the same script (I've misspelled "failed" on purpose to ensure I was using the right library):
```
~/Documents/python-lz4 (master) ✗ 
[20:39:01] Φ memray run --native script.py                       
Writing profile results into memray-script.py.10164.bin
Memray WARNING: Correcting symbol for malloc from 0x420480 to 0x7f90d4096b10
Memray WARNING: Correcting symbol for free from 0x4207a0 to 0x7f90d40970d0
Memray WARNING: Correcting symbol for aligned_alloc from 0x7f90c6441f00 to 0x7f90d4097850
4.0.2.dev0+ga19f75d.d20220704
initial
28.01171875
LZ4F_decompress faile with code: ERROR_GENERIC
0
28.1640625
LZ4F_decompress faile with code: ERROR_GENERIC
1
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
2
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
3
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
4
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
5
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
6
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
7
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
8
28.16796875
LZ4F_decompress faile with code: ERROR_GENERIC
9
28.16796875
[memray] Successfully generated profile results.

You can now generate reports from the stored allocation records.
Some example commands to generate reports:
```
Memray trace:
![image](https://user-images.githubusercontent.com/15343819/177210357-1c8f4a42-9882-4234-880d-d6bf83e659f1.png)

