### PR TITLE
fix(doc): Install command missing a parameter

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,7 +40,7 @@ this command will result in the extension modules being compiled from source::
 On systems for which pre-built wheels are available, the following command will
 force a local compilation of the extension modules from source::
 
-  $ pip install --no-binary --no-cache-dir lz4
+  $ pip install --no-binary :all: --no-cache-dir lz4
 
 The package can also be installed manually from a checkout of the source code
 git repository::


### PR DESCRIPTION
The `--no-binary` option needs a parameter, as indicated in the pip documentation here https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary

Same issue was reported here https://github.com/psycopg/psycopg2/issues/673 so I used the same `:all:` syntax opted for by the package maintainer. 