### PR TITLE
chore: wheel is not required for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", "pkgconfig"]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2", "pkgconfig"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Wheel has never been required in `build-system.requires` unless you used `import wheel` in `setup.py` (which you should not, wheel doesn't have a public API) - it's requested by setuptools via a hook. And modern setuptools doesn't even use `wheel` anymore.