### PR TITLE
ci: fixup and modernize CI

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Save wheels
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-${{ strategy.job-index }}
+          name: cibw-wheels-${{ strategy.job-index }}c 
           path: wheelhouse/*.whl
 
   upload_pypi:

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -1,13 +1,14 @@
 name: Build
 
-# on: [push, pull_request, release]
-
 on:
   push:
-    branches:
   release:
     types: [created]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   sdist:
@@ -15,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0  # To ensure tags are retrieved to enabe setuptools_scm to work
     - name: Install Python 3.x
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.x
     - name: Install setuptools
@@ -27,8 +28,9 @@ jobs:
     - name: Build sdist
       run: python setup.py sdist
     - name: Save sdist
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
+        name: cibw-sdist
         path: dist/*.tar.gz
 
   wheels:
@@ -36,28 +38,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest] 
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest] 
         cibw_build: [cp38-*, cp39-*, cp310-*, cp311-*, cp312-*]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # To ensure tags are retrieved to enabe setuptools_scm to work
-      - name: Install Python 3.x
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
       - name: Set up QEMU  # Needed to build aarch64 wheels
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.21
         env:
           CIBW_ENVIRONMENT: PYLZ4_USE_SYSTEM_LZ4="False"
           CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
-          CIBW_ARCHS_MACOS: "x86_64 arm64" # universal2"
+          CIBW_ARCHS_MACOS: "auto64"
           CIBW_ARCHS_WINDOWS: "AMD64 x86"
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
@@ -65,8 +63,9 @@ jobs:
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-*linux_{aarch64,ppc64le,s390x}"
           CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
       - name: Save wheels
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
+          name: cibw-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
   upload_pypi:
@@ -75,10 +74,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: artifact
+          pattern: cibw-*
           path: dist
+          merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Modernized. See https://learn.scientific-python.org/development/guides/gha-basic/ for help in setting up CI.

Closes #285. Closes #283. Should enable the existing stuck PRs #289, #288, and #284.
