### PR TITLE
ci: fix collection of artifacts for PyPI upload

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Save sdist
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-sdist.tar.gz
+          name: cibw-sdist
           path: dist/*.tar.gz
 
   wheels:
@@ -80,7 +80,7 @@ jobs:
       - name: Save wheels
         uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ strategy.job-index }}.whl
+          name: cibw-wheels-${{ strategy.job-index }}
           path: wheelhouse/*.whl
 
   upload_pypi:
@@ -93,6 +93,7 @@ jobs:
         with:
           pattern: cibw-*
           path: dist
+          merge-multiple: true
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Current problem is that the `cibw-wheels-*.whl` artifacts contain multiple wheels. These are then added to the `dist` directory as subdirectories (e.g. `dist/cibw-wheels-0.whl/lz4-4.4.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`). `twine` sees `*.whl` directories as wheel-files and thus fails.

https://github.com/actions/download-artifact has an option `merge-multiple`, which when set to `true` should add all files to the same directory.