### PR TITLE
Enable CPython free-threaded wheel builds

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -121,7 +121,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=2" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=1" >> "$GITHUB_ENV"
           echo "CIBW_TEST_COMMAND=tox -x testenv.deps+=pytest-run-parallel -x testenv.pass_env+=PYTEST_ADDOPTS -c {project}" >> "$GITHUB_ENV"
       - name: Setup environment
         if: ${{ !endsWith(matrix.cibw_build, 't-*') }}

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -69,12 +69,12 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4 TOX_OVERRIDE=testenv.deps+=pytest-run-parallel;testenv.pass_env=PYTEST_ADDOPTS"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4 TOX_OVERRIDE=testenv.deps+=pytest-run-parallel;testenv.pass_env=PYTEST_ADDOPTS" >> "$GITHUB_ENV"
       - name: Setup environment
         if: ${{ !endsWith(matrix.cibw_build, 't-*') }}
         shell: bash -l {0}
         run: |
-          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4="False" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False" >> "$GITHUB_ENV"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         env:

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -130,7 +130,7 @@ jobs:
           echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False" >> "$GITHUB_ENV"
           echo "CIBW_TEST_COMMAND=tox -c {project}" >> "$GITHUB_ENV"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_ARCHS_LINUX: "aarch64 armv7l"
           CIBW_BUILD: ${{ matrix.cibw_build }}

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -48,7 +48,7 @@ jobs:
           - macos-13 # x86
           - macos-latest # arm
           - windows-latest
-        cibw_build: [cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
+        cibw_build: [cp39-*, cp310-*, cp311-*, cp312-*, cp313-*, cp313t-*]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -63,6 +63,14 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
+      - name: Setup free-threading variables
+        if: ${{ endsWith(matrix.cibw_build, 't-*') }}
+        shell: bash -l {0}
+        run: |
+          echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
+          echo "TOX_OVERRIDE=testenv.deps+=pytest-run-parallel" >> "$GITHUB_ENV"
+          echo "PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
@@ -110,6 +118,7 @@ jobs:
           CIBW_ARCHS_LINUX: "aarch64 armv7l"
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
+          CIBW_ENABLE: cpython-freethreading
           CIBW_TEST_COMMAND: "tox -c {project}"
           CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
       - name: Save wheels

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -72,7 +72,7 @@ jobs:
           echo "TOX_OVERRIDE=testenv.deps+=pytest-run-parallel" >> "$GITHUB_ENV"
           echo "PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21
+        uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_ENVIRONMENT: PYLZ4_USE_SYSTEM_LZ4="False"
           # CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -121,7 +121,7 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=2" >> "$GITHUB_ENV"
           echo "CIBW_TEST_COMMAND=tox -x testenv.deps+=pytest-run-parallel -x testenv.pass_env+=PYTEST_ADDOPTS -c {project}" >> "$GITHUB_ENV"
       - name: Setup environment
         if: ${{ !endsWith(matrix.cibw_build, 't-*') }}

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -84,9 +84,9 @@ jobs:
           CIBW_ARCHS_LINUX: "x86_64 i686"
           CIBW_ARCHS_MACOS: "auto64" # since we have both runner arches
           CIBW_ARCHS_WINDOWS: "AMD64 x86 ARM64"
+          CIBW_ENABLE: cpython-freethreading
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
-          CIBW_TEST_COMMAND: "tox -c {project}"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-*linux_{ppc64le,s390x} *-win_arm64"
           CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
       - name: Save wheels
@@ -106,7 +106,7 @@ jobs:
       matrix:
         os:
           - ubuntu-24.04-arm
-        cibw_build: [cp39-*, cp310-*, cp311-*, cp312-*, cp313-*]
+        cibw_build: [cp39-*, cp310-*, cp311-*, cp312-*, cp313-*, cp313t-*]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -116,15 +116,26 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.x
+      - name: Setup free-threading variables
+        if: ${{ endsWith(matrix.cibw_build, 't-*') }}
+        shell: bash -l {0}
+        run: |
+          echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
+          echo "CIBW_TEST_COMMAND=tox -x testenv.deps+=pytest-run-parallel -x testenv.pass_env+=PYTEST_ADDOPTS -c {project}" >> "$GITHUB_ENV"
+      - name: Setup environment
+        if: ${{ !endsWith(matrix.cibw_build, 't-*') }}
+        shell: bash -l {0}
+        run: |
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False" >> "$GITHUB_ENV"
+          echo "CIBW_TEST_COMMAND=tox -c {project}" >> "$GITHUB_ENV"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.21
         env:
-          CIBW_ENVIRONMENT: PYLZ4_USE_SYSTEM_LZ4="False"
           CIBW_ARCHS_LINUX: "aarch64 armv7l"
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
           CIBW_ENABLE: cpython-freethreading
-          CIBW_TEST_COMMAND: "tox -c {project}"
           CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
       - name: Save wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         env:
-          CIBW_ARCHS_LINUX: "aarch64 armv7l"
+          CIBW_ARCHS_LINUX: "aarch64"
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
           CIBW_ENABLE: cpython-freethreading

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -69,12 +69,15 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "TOX_OVERRIDE=testenv.deps+=pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4 TOX_OVERRIDE=testenv.deps+=pytest-run-parallel;testenv.pass_env=PYTEST_ADDOPTS"
+      - name: Setup environment
+        if: ${{ !endsWith(matrix.cibw_build, 't-*') }}
+        shell: bash -l {0}
+        run: |
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4="False" >> "$GITHUB_ENV"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         env:
-          CIBW_ENVIRONMENT: PYLZ4_USE_SYSTEM_LZ4="False"
           # CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
           CIBW_ARCHS_LINUX: "x86_64 i686"
           CIBW_ARCHS_MACOS: "auto64" # since we have both runner arches

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -69,12 +69,14 @@ jobs:
         shell: bash -l {0}
         run: |
           echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
-          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4 TOX_OVERRIDE=testenv.deps+=pytest-run-parallel;testenv.pass_env=PYTEST_ADDOPTS" >> "$GITHUB_ENV"
+          echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=4" >> "$GITHUB_ENV"
+          echo "CIBW_TEST_COMMAND=tox -x testenv.deps+=pytest-run-parallel -x testenv.pass_env+=PYTEST_ADDOPTS -c {project}" >> "$GITHUB_ENV"
       - name: Setup environment
         if: ${{ !endsWith(matrix.cibw_build, 't-*') }}
         shell: bash -l {0}
         run: |
           echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False" >> "$GITHUB_ENV"
+          echo "CIBW_TEST_COMMAND=tox -c {project}" >> "$GITHUB_ENV"
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.2
         env:

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -120,6 +120,8 @@ jobs:
         if: ${{ endsWith(matrix.cibw_build, 't-*') }}
         shell: bash -l {0}
         run: |
+          # Variables are set in order to be passed down to both cibuildwheel and the
+          # Docker image spawned by that action
           echo "CIBW_BEFORE_TEST=pip install pytest pytest-run-parallel" >> "$GITHUB_ENV"
           echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False PYTEST_ADDOPTS=--parallel-threads=1" >> "$GITHUB_ENV"
           echo "CIBW_TEST_COMMAND=tox -x testenv.deps+=pytest-run-parallel -x testenv.pass_env+=PYTEST_ADDOPTS -c {project}" >> "$GITHUB_ENV"

--- a/lz4/_version.c
+++ b/lz4/_version.c
@@ -114,7 +114,7 @@ PyInit__version(void)
     return NULL;
 
   #ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
   #endif
 
   return module;

--- a/lz4/_version.c
+++ b/lz4/_version.c
@@ -113,5 +113,9 @@ PyInit__version(void)
   if (module == NULL)
     return NULL;
 
+  #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+  #endif
+
   return module;
 }

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -518,5 +518,9 @@ PyInit__block(void)
   Py_INCREF(LZ4BlockError);
   PyModule_AddObject(module, "LZ4BlockError", LZ4BlockError);
 
+  #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+  #endif
+
   return module;
 }

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -519,7 +519,7 @@ PyInit__block(void)
   PyModule_AddObject(module, "LZ4BlockError", LZ4BlockError);
 
   #ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
   #endif
 
   return module;

--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -1677,5 +1677,9 @@ PyInit__frame(void)
   PyModule_AddIntConstant (module, "BLOCKSIZE_MAX1MB", LZ4F_max1MB);
   PyModule_AddIntConstant (module, "BLOCKSIZE_MAX4MB", LZ4F_max4MB);
 
+  #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+  #endif
+
   return module;
 }

--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -1678,7 +1678,7 @@ PyInit__frame(void)
   PyModule_AddIntConstant (module, "BLOCKSIZE_MAX4MB", LZ4F_max4MB);
 
   #ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
   #endif
 
   return module;

--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -1649,5 +1649,9 @@ PyInit__stream(void)
   Py_INCREF (LZ4StreamError);
   PyModule_AddObject (module, "LZ4StreamError", LZ4StreamError);
 
+  #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+  #endif
+
   return module;
 }

--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -1650,7 +1650,7 @@ PyInit__stream(void)
   PyModule_AddObject (module, "LZ4StreamError", LZ4StreamError);
 
   #ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(mod, Py_MOD_GIL_NOT_USED);
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
   #endif
 
   return module;

--- a/tests/block/conftest.py
+++ b/tests/block/conftest.py
@@ -3,24 +3,6 @@ import os
 import sys
 
 
-class EmptyMemoryView():
-    def __init__(self):
-        self.data = b''
-        self.view = None
-
-    def __buffer__(self, flags: int, /) -> memoryview:
-        if self.view is None:
-            self.view = memoryview(self.data)
-            return self.view
-
-    def __release_buffer__(self, buffer: memoryview, /):
-        breakpoint()
-        buffer.release()
-
-    def __len__(self):
-        return 0
-
-
 test_data = [
     (b''),
     (os.urandom(8 * 1024)),

--- a/tests/block/conftest.py
+++ b/tests/block/conftest.py
@@ -3,6 +3,24 @@ import os
 import sys
 
 
+class EmptyMemoryView():
+    def __init__(self):
+        self.data = b''
+        self.view = None
+
+    def __buffer__(self, flags: int, /) -> memoryview:
+        if self.view is None:
+            self.view = memoryview(self.data)
+            return self.view
+
+    def __release_buffer__(self, buffer: memoryview, /):
+        breakpoint()
+        buffer.release()
+
+    def __len__(self):
+        return 0
+
+
 test_data = [
     (b''),
     (os.urandom(8 * 1024)),

--- a/tests/block/test_block_0.py
+++ b/tests/block/test_block_0.py
@@ -2,7 +2,6 @@ import lz4.block
 from multiprocessing.pool import ThreadPool
 import sys
 import copy
-import inspect
 import pytest
 from functools import partial
 if sys.version_info <= (3, 2):

--- a/tests/block/test_block_0.py
+++ b/tests/block/test_block_0.py
@@ -70,6 +70,13 @@ def setup_kwargs(mode, store_size, c_return_bytearray=None, d_return_bytearray=N
 
 # Test single threaded usage with all valid variations of input
 def test_1(data, mode, store_size, c_return_bytearray, d_return_bytearray, dictionary):
+    if isinstance(data, memoryview):
+        data = memoryview(copy.deepcopy(data.obj))
+    elif isinstance(data, bytearray):
+        data_x = bytearray()
+        data_x[:] = data
+        data = data_x
+
     (c_kwargs, d_kwargs) = setup_kwargs(
         mode, store_size, c_return_bytearray, d_return_bytearray)
 

--- a/tests/block/test_block_0.py
+++ b/tests/block/test_block_0.py
@@ -1,6 +1,9 @@
 import lz4.block
 from multiprocessing.pool import ThreadPool
 import sys
+import copy
+import inspect
+import pytest
 from functools import partial
 if sys.version_info <= (3, 2):
     import struct
@@ -79,10 +82,19 @@ def test_1(data, mode, store_size, c_return_bytearray, d_return_bytearray, dicti
 
 
 # Test multi threaded usage with all valid variations of input
+@pytest.mark.thread_unsafe
 def test_2(data, mode, store_size, dictionary):
     (c_kwargs, d_kwargs) = setup_kwargs(mode, store_size)
 
-    data_in = [data for i in range(32)]
+    def copy_buf(data):
+        data_x = data
+        if isinstance(data, memoryview):
+            data_x = memoryview(copy.deepcopy(data.obj))
+        elif isinstance(data, bytearray):
+            data_x = bytearray(copy.deepcopy(data.__buffer__(inspect.BufferFlags.FULL_RO).obj))
+        return data_x
+
+    data_in = [copy_buf(data) for i in range(32)]
 
     pool = ThreadPool(2)
     rt = partial(roundtrip, c_kwargs=c_kwargs,

--- a/tests/block/test_block_0.py
+++ b/tests/block/test_block_0.py
@@ -93,12 +93,13 @@ def test_2(data, mode, store_size, dictionary):
     (c_kwargs, d_kwargs) = setup_kwargs(mode, store_size)
 
     def copy_buf(data):
-        data_x = data
         if isinstance(data, memoryview):
             data_x = memoryview(copy.deepcopy(data.obj))
         elif isinstance(data, bytearray):
             data_x = bytearray()
             data_x[:] = data
+        else:
+            data_x = data
         return data_x
 
     data_in = [copy_buf(data) for i in range(32)]

--- a/tests/block/test_block_0.py
+++ b/tests/block/test_block_0.py
@@ -91,7 +91,8 @@ def test_2(data, mode, store_size, dictionary):
         if isinstance(data, memoryview):
             data_x = memoryview(copy.deepcopy(data.obj))
         elif isinstance(data, bytearray):
-            data_x = bytearray(copy.deepcopy(data.__buffer__(inspect.BufferFlags.FULL_RO).obj))
+            data_x = bytearray()
+            data_x[:] = data
         return data_x
 
     data_in = [copy_buf(data) for i in range(32)]

--- a/tests/block/test_block_3.py
+++ b/tests/block/test_block_3.py
@@ -18,6 +18,7 @@ def data(request):
     return request.param
 
 
+@pytest.mark.thread_unsafe
 def test_block_decompress_mem_usage(data):
     tracemalloc = pytest.importorskip('tracemalloc')
 

--- a/tests/frame/test_frame_2.py
+++ b/tests/frame/test_frame_2.py
@@ -46,7 +46,9 @@ def test_roundtrip_chunked(data, block_size, block_linked,
     if isinstance(data, memoryview):
         data = memoryview(copy.deepcopy(data.obj))
     elif isinstance(data, bytearray):
-        data = bytearray(copy.deepcopy(data.__buffer__(inspect.BufferFlags.FULL_RO).obj))
+        data_2 = bytearray()
+        data_2[:] = data
+        data = data_2
 
     c_context = lz4frame.create_compression_context()
 

--- a/tests/frame/test_frame_2.py
+++ b/tests/frame/test_frame_2.py
@@ -2,7 +2,6 @@ import lz4.frame as lz4frame
 import pytest
 import os
 import copy
-import inspect
 import sys
 from . helpers import (
     get_chunked,

--- a/tests/frame/test_frame_2.py
+++ b/tests/frame/test_frame_2.py
@@ -1,6 +1,8 @@
 import lz4.frame as lz4frame
 import pytest
 import os
+import copy
+import inspect
 import sys
 from . helpers import (
     get_chunked,
@@ -40,6 +42,11 @@ def test_roundtrip_chunked(data, block_size, block_linked,
                            auto_flush, store_size):
 
     data, c_chunks, d_chunks = data
+
+    if isinstance(data, memoryview):
+        data = memoryview(copy.deepcopy(data.obj))
+    elif isinstance(data, bytearray):
+        data = bytearray(copy.deepcopy(data.__buffer__(inspect.BufferFlags.FULL_RO).obj))
 
     c_context = lz4frame.create_compression_context()
 

--- a/tests/frame/test_frame_5.py
+++ b/tests/frame/test_frame_5.py
@@ -8,6 +8,8 @@ test_data = [
     (b'a' * 1024 * 1024),
 ]
 
+pytestmark = pytest.mark.thread_unsafe
+
 
 @pytest.fixture(
     params=test_data,
@@ -66,17 +68,17 @@ def test_frame_decompress_chunk_mem_usage(data):
             prev_snapshot = snapshot
 
 
-def test_frame_open_decompress_mem_usage(data):
+def test_frame_open_decompress_mem_usage(tmp_path, data):
     tracemalloc = pytest.importorskip('tracemalloc')
     tracemalloc.start()
 
-    with lz4.frame.open('test.lz4', 'w') as f:
+    with lz4.frame.open(tmp_path / 'test.lz4', 'w') as f:
         f.write(data)
 
     prev_snapshot = None
 
     for i in range(1000):
-        with lz4.frame.open('test.lz4', 'r') as f:
+        with lz4.frame.open(tmp_path / 'test.lz4', 'r') as f:
             decompressed = f.read()  # noqa: F841
 
         if i % 100 == 0:

--- a/tests/frame/test_frame_5.py
+++ b/tests/frame/test_frame_5.py
@@ -68,17 +68,17 @@ def test_frame_decompress_chunk_mem_usage(data):
             prev_snapshot = snapshot
 
 
-def test_frame_open_decompress_mem_usage(tmp_path, data):
+def test_frame_open_decompress_mem_usage(data):
     tracemalloc = pytest.importorskip('tracemalloc')
     tracemalloc.start()
 
-    with lz4.frame.open(tmp_path / 'test.lz4', 'w') as f:
+    with lz4.frame.open('test.lz4', 'w') as f:
         f.write(data)
 
     prev_snapshot = None
 
     for i in range(1000):
-        with lz4.frame.open(tmp_path / 'test.lz4', 'r') as f:
+        with lz4.frame.open('test.lz4', 'r') as f:
             decompressed = f.read()  # noqa: F841
 
         if i % 100 == 0:

--- a/tests/frame/test_frame_8.py
+++ b/tests/frame/test_frame_8.py
@@ -1,12 +1,14 @@
+import threading
 import lz4.frame as lz4frame
 
 
-def test_lz4frame_open_write_read_text_iter():
+def test_lz4frame_open_write_read_text_iter(tmp_path):
     data = u'This is a test string'
-    with lz4frame.open('testfile', mode='wt') as fp:
+    thread_id = threading.get_native_id()
+    with lz4frame.open(tmp_path / f'testfile_{thread_id}', mode='wt') as fp:
         fp.write(data)
     data_out = ''
-    with lz4frame.open('testfile', mode='rt') as fp:
+    with lz4frame.open(tmp_path / f'testfile_{thread_id}', mode='rt') as fp:
         for line in fp:
             data_out += line
     assert data_out == data

--- a/tests/frame/test_frame_9.py
+++ b/tests/frame/test_frame_9.py
@@ -3,11 +3,12 @@ import os
 import io
 import pickle
 import sys
+import threading
 import lz4.frame
 import pytest
 
 
-def test_issue_172_1():
+def test_issue_172_1(tmp_path):
     """Test reproducer for issue 172
 
     Issue 172 is a reported failure occurring on Windows 10 only. This bug was
@@ -16,34 +17,38 @@ def test_issue_172_1():
 
     """
     input_data = 8 * os.urandom(1024)
-    with lz4.frame.open('testfile_small', 'wb') as fp:
+    thread_id = threading.get_native_id()
+
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'wb') as fp:
         bytes_written = fp.write(input_data)  # noqa: F841
 
-    with lz4.frame.open('testfile_small', 'rb') as fp:
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'rb') as fp:
         data = fp.read(10)
         assert len(data) == 10
 
 
-def test_issue_172_2():
+def test_issue_172_2(tmp_path):
     input_data = 9 * os.urandom(1024)
-    with lz4.frame.open('testfile_small', 'w') as fp:
+    thread_id = threading.get_native_id()
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'w') as fp:
         bytes_written = fp.write(input_data)  # noqa: F841
 
-    with lz4.frame.open('testfile_small', 'r') as fp:
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'r') as fp:
         data = fp.read(10)
         assert len(data) == 10
 
 
-def test_issue_172_3():
+def test_issue_172_3(tmp_path):
     input_data = 9 * os.urandom(1024)
-    with lz4.frame.open('testfile_small', 'wb') as fp:
+    thread_id = threading.get_native_id()
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'wb') as fp:
         bytes_written = fp.write(input_data)  # noqa: F841
 
-    with lz4.frame.open('testfile_small', 'rb') as fp:
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'rb') as fp:
         data = fp.read(10)
         assert len(data) == 10
 
-    with lz4.frame.open('testfile_small', 'rb') as fp:
+    with lz4.frame.open(tmp_path / f'testfile_small_{thread_id}', 'rb') as fp:
         data = fp.read(16 * 1024 - 1)
         assert len(data) == 9 * 1024
         assert data == input_data

--- a/tests/stream/test_stream_0.py
+++ b/tests/stream/test_stream_0.py
@@ -96,6 +96,7 @@ def setup_kwargs(strategy, mode, buffer_size, store_comp_size,
 
 
 # Test single threaded usage with all valid variations of input
+@pytest.mark.thread_unsafe
 def test_1(data, strategy, mode, buffer_size, store_comp_size,
            c_return_bytearray, d_return_bytearray, dictionary):
     if buffer_size >= (1 << (8 * store_comp_size['store_comp_size'])):

--- a/tests/stream/test_stream_3.py
+++ b/tests/stream/test_stream_3.py
@@ -71,6 +71,7 @@ def data(request):
     return request.param
 
 
+@pytest.mark.thread_unsafe
 def test_block_decompress_mem_usage(data, buffer_size):
     kwargs = {
         'strategy': "double_buffer",


### PR DESCRIPTION
Fixes https://github.com/python-lz4/python-lz4/issues/292

This PR enables support for free-threading builds of `python-lz4`, in particular this diff achieves the following goals:

- [x] Checking that the test suite is free-threading compliant by using `pytest-run-parallel`, which executes each test in a concurrent fashion. Such check did not raise any major concurrency issues related neither to race conditions nor memory manipulation that could lead to segfaults. The only tests marked to be single-threaded were the ones related to check for memory usage.
- [x] Testing, building, packaging and publishing free-threaded wheels via CI
- [x] Marking each C module as free-threaded compatible
- [x] Checking that there are no major C thread issues using Thread Sanitizer (TSAN)

Overall, this package does not have any major C threading issues, given that the underlying library is thread safe https://github.com/lz4/lz4/issues/887#issuecomment-663653157 (at least when each thread owns its own compression/decompression context).