### PR TITLE
Add a GitHub Action to run pytest on Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: ci
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  pytest:
+    strategy:
+      fail-fast: false
+      matrix:  # https://github.com/actions/python-versions/releases
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - run: pip install --upgrade pip
+      - run: if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - run: pip install --editable . || true
+      - run: pip install psutil
+      - run: pytest


### PR DESCRIPTION
Caution: The new `compression` module in Python >= 3.14 Standard Library causes compatibility problems.
* https://docs.python.org/3.14/library/compression.html
* ~#302~
* ~#303~
* #308 

---
Python v3.14
* https://www.python.org/downloads/release/python-3140/
* https://docs.python.org/3.14/whatsnew/3.14.html

What's new in Python 3.14: ___PEP 784: Adding Zstandard to the standard library___
* https://docs.python.org/3.14/whatsnew/3.14.html#whatsnew314-pep784