### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/lz4/frame/__init__.py
+++ b/lz4/frame/__init__.py
@@ -268,7 +268,7 @@ class LZ4FrameCompressor(object):
         This returns a ``bytes`` or ``bytearray`` object containing any data
         stored in the compressor's internal buffers and a frame footer.
 
-        The LZ4FrameCompressor instance may be re-used after this method has
+        The LZ4FrameCompressor instance may be reused after this method has
         been called to create a new frame of compressed data.
 
         Returns:
@@ -287,7 +287,7 @@ class LZ4FrameCompressor(object):
     def reset(self):
         """Reset the `LZ4FrameCompressor` instance.
 
-        This allows the `LZ4FrameCompression` instance to be re-used after an
+        This allows the `LZ4FrameCompression` instance to be reused after an
         error.
 
         """
@@ -360,7 +360,7 @@ class LZ4FrameDecompressor(object):
     def reset(self):
         """Reset the decompressor state.
 
-        This is useful after an error occurs, allowing re-use of the instance.
+        This is useful after an error occurs, allowing reuse of the instance.
 
         """
         reset_decompression_context(self._context)

--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -1330,7 +1330,7 @@ PyDoc_STRVAR(
  );
 
 #define COMPRESS_KWARGS_DOCSTRING                                       \
-  "    block_size (int): Sepcifies the maximum blocksize to use.\n"     \
+  "    block_size (int): Specifies the maximum blocksize to use.\n"     \
   "        Options:\n\n"                                                \
   "        - `lz4.frame.BLOCKSIZE_DEFAULT`: the lz4 library default\n" \
   "        - `lz4.frame.BLOCKSIZE_MAX64KB`: 64 kB\n"             \
@@ -1466,7 +1466,7 @@ PyDoc_STRVAR
  "data will also be included in the returned data.\n"                   \
  "\n"                                                                   \
  "If the ``end_frame`` argument is ``True``, the compression context will be\n" \
- "reset and can be re-used.\n"                                          \
+ "reset and can be reused.\n"                                          \
  "\n"                                                                   \
  "Args:\n"                                                              \
  "    context (cCtx): Compression context\n"                            \

--- a/lz4/stream/__init__.py
+++ b/lz4/stream/__init__.py
@@ -32,7 +32,7 @@ class LZ4StreamDecompressor:
                     perform decompression using this initial dictionary.
 
             Raises:
-                Exceptions occuring during the context initialization.
+                Exceptions occurring during the context initialization.
 
                 OverflowError: raised if the ``dictionary`` parameter is too large
                     for the LZ4 context.
@@ -73,7 +73,7 @@ class LZ4StreamDecompressor:
                 bytes or bytearray: Decompressed data.
 
             Raises:
-                Exceptions occuring during decompression.
+                Exceptions occurring during decompression.
 
                 ValueError: raised if the source is inconsistent with a finite LZ4
                     stream block chain.
@@ -96,7 +96,7 @@ class LZ4StreamDecompressor:
                 bytes or bytearray: LZ4 compressed data block.
 
             Raises:
-                Exceptions occuring while getting the first block from ``stream``.
+                Exceptions occurring while getting the first block from ``stream``.
 
                 BufferError: raised if the function cannot return a complete LZ4
                     compressed block from the stream (i.e. the stream does not hold
@@ -150,7 +150,7 @@ class LZ4StreamCompressor:
                     perform compression using this initial dictionary.
 
             Raises:
-                Exceptions occuring during the context initialization.
+                Exceptions occurring during the context initialization.
 
                 OverflowError: raised if the ``dictionary`` parameter is too large
                     for the LZ4 context.
@@ -194,7 +194,7 @@ class LZ4StreamCompressor:
                 bytes or bytearray: Compressed data.
 
             Raises:
-                Exceptions occuring during compression.
+                Exceptions occurring during compression.
 
                 OverflowError: raised if the source is too large for being compressed in
                     the given context.

--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -931,7 +931,7 @@ _create_context (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwds)
       context->output.len = buffer_size;
       total_size = context->output.len;
 
-      /* Here we cannot assert the maximal theorical decompressed chunk length
+      /* Here we cannot assert the maximal theoretical decompressed chunk length
        * will fit in one page of the double_buffer, i.e.:
        *    assert( !(double_buffer.page_size < _LZ4_inputBound(store_max_size)) )
        *

--- a/tests/frame/test_frame_9.py
+++ b/tests/frame/test_frame_9.py
@@ -65,7 +65,7 @@ def test_issue_227_1():
 
 @pytest.mark.skipif(
     sys.version_info < (3, 8),
-    reason="PickleBuffer only availiable in Python 3.8 or greater"
+    reason="PickleBuffer only available in Python 3.8 or greater"
 )
 def test_issue_227_2():
     q = array.array('Q', [1, 2, 3, 4, 5])

--- a/tests/stream/test_stream_0.py
+++ b/tests/stream/test_stream_0.py
@@ -112,6 +112,6 @@ def test_1(data, strategy, mode, buffer_size, store_comp_size,
 
 # Test multi threaded:
 #   Not relevant in the lz4.stream case (the process is highly sequential,
-#   and re-use/share the same context from one input chunk to the next one).
+#   and reuse/share the same context from one input chunk to the next one).
 def test_2(data, strategy, mode, buffer_size, store_comp_size, dictionary): # noqa
     pass

--- a/tests/stream/test_stream_1.py
+++ b/tests/stream/test_stream_1.py
@@ -136,7 +136,7 @@ def test_invalid_config_c_4(store_comp_size):
     c_kwargs.update(store_comp_size)
 
     if store_comp_size['store_comp_size'] >= 4:
-        # No need for skiping this test case, since arguments check is
+        # No need for skipping this test case, since arguments check is
         # expecting to raise an error.
 
         # Make sure the page size is larger than what the input bound will be,
@@ -169,7 +169,7 @@ def test_invalid_config_d_4(store_comp_size):
         # but still fit in 4 bytes
         d_kwargs['buffer_size'] -= 1
 
-    # No failure expected during instanciation/initialization
+    # No failure expected during instantiation/initialization
     lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
 
@@ -199,7 +199,7 @@ def test_invalid_config_d_5():
     d_kwargs = {}
     d_kwargs['strategy'] = "double_buffer"
 
-    # No failure expected during instanciation/initialization
+    # No failure expected during instantiation/initialization
     d_kwargs['buffer_size'] = lz4.stream.LZ4_MAX_INPUT_SIZE
 
     if sys.maxsize < 0xffffffff:
@@ -207,7 +207,7 @@ def test_invalid_config_d_5():
 
     lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
-    # No failure expected during instanciation/initialization
+    # No failure expected during instantiation/initialization
     d_kwargs['buffer_size'] = lz4.stream.LZ4_MAX_INPUT_SIZE + 1
 
     if sys.maxsize < 0xffffffff:
@@ -215,7 +215,7 @@ def test_invalid_config_d_5():
 
     lz4.stream.LZ4StreamDecompressor(**d_kwargs)
 
-    # No failure expected during instanciation/initialization
+    # No failure expected during instantiation/initialization
     d_kwargs['buffer_size'] = _4GB - 1  # 4GB - 1 (to fit in 4 bytes)
 
     if sys.maxsize < 0xffffffff:


### PR DESCRIPTION
% `codespell --ignore-words-list=collet,inout,strat --quiet=1 --skip="lz4libs/*" --write-changes`
* https://pypi.org/project/codespell