### PR TITLE
`setup.py`: Add trove classifiers for Python 3.14 and Free Threading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -205,5 +205,7 @@ setup(
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
+        'Programming Language :: Python :: Free Threading',
     ],
 )


### PR DESCRIPTION
```diff
+        'Programming Language :: Python :: 3.14',
+        'Programming Language :: Python :: Free Threading',
```
Updates the lower left of https://pypi.org/project/lz4