### PR TITLE
Strip debug symbols from lz4 build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,8 @@ elif compiler in ('unix', 'mingw32'):
             '-Wall',
             '-Wundef'
         ]
+        # strip debug symbols from libraries to reduce wheel size
+        extension_kwargs['extra_link_args'] = ['-s']
 else:
     print('Unrecognized compiler: {0}'.format(compiler))
     sys.exit(1)


### PR DESCRIPTION
When a wheel is built using lz4 library source files bundled with the package, we advise the linker to strip debug symbols from the binary output.

This leads to a significant size reduction of the wheel. Comparison of local build with lz4 1.10.0:
```
master      1324506 lz4-4.4.6.dev1+gd5daffd83-cp312-cp312-linux_x86_64.whl
this patch   294389 lz4-4.4.6.dev1+gd5daffd83.d20260112-cp312-cp312-linux_x86_64.whl
```

Fixes #305