### PR TITLE
Fix PyArg_ParseTuple format mismatch and non-NULL return with exception in stream module

### DIFF
--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -215,6 +215,8 @@ compress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
   dest = PyMem_Malloc (total_size * sizeof * dest);
   if (dest == NULL)
     {
+      PyBuffer_Release(&source);
+      PyBuffer_Release(&dict);
       return PyErr_NoMemory();
     }
 
@@ -349,6 +351,8 @@ decompress (PyObject * Py_UNUSED (self), PyObject * args, PyObject * kwargs)
   dest = PyMem_Malloc (dest_size * sizeof * dest);
   if (dest == NULL)
     {
+      PyBuffer_Release(&source);
+      PyBuffer_Release(&dict);
       return PyErr_NoMemory();
     }
 

--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -184,6 +184,7 @@ compress (PyObject * Py_UNUSED (self), PyObject * args,
     }
   else if (block_checksum)
     {
+      PyBuffer_Release(&source);
       PyErr_SetString (PyExc_RuntimeError,
                        "block_checksum specified but not supported by LZ4 library version");
       return NULL;
@@ -383,6 +384,7 @@ compress_begin (PyObject * Py_UNUSED (self), PyObject * args,
 
   if (LZ4F_isError (result))
     {
+      PyMem_Free (destination);
       PyErr_Format (PyExc_RuntimeError,
                     "LZ4F_compressBegin failed with code: %s",
                     LZ4F_getErrorName (result));
@@ -1115,6 +1117,7 @@ __decompress(LZ4F_dctx * context, char * source, size_t source_size,
               buff = PyMem_Realloc (destination, destination_size);
               if (buff == NULL)
                 {
+                  PyMem_Free (destination);
                   PyErr_SetString (PyExc_RuntimeError,
                                    "Failed to resize buffer");
                   return NULL;

--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -1063,7 +1063,7 @@ _compress_bound (PyObject * Py_UNUSED (self), PyObject * args)
   /* Positional arguments: input_size
    * Keyword arguments   : none
    */
-  if (!PyArg_ParseTuple (args, "OI", &input_size))
+  if (!PyArg_ParseTuple (args, "I", &input_size))
     {
       goto exit_now;
     }
@@ -1211,6 +1211,7 @@ _compress (PyObject * Py_UNUSED (self), PyObject * args)
 
   if (context->strategy.ops->update_context_after_process (context) != 0)
     {
+      Py_CLEAR (py_dest);
       PyErr_Format (PyExc_RuntimeError, "Internal error");
       goto exit_now;
     }


### PR DESCRIPTION
## Summary

- Fix `_compress_bound`: format `"OI"` expects `(PyObject*, unsigned int)` but only `&input_size` (`uint32_t*`) is provided — the `"O"` writes a `PyObject*` into a `uint32_t`, causing type mismatch and undefined behavior on every call. Changed to `"I"` to match the identical `_input_bound` function at line 1091.

- Fix `_compress`: when `update_context_after_process` fails, `PyErr_Format` sets an exception but `goto exit_now` returns the already-created `py_dest` (non-NULL). This violates the Python/C API contract (returning a result with an exception set), causing `SystemError`. Added `Py_CLEAR(py_dest)` before the goto.

## Context

The `"OI"` vs `"I"` bug appears to be a copy-paste error — `_input_bound` on line 1091 has the correct `"I"` format for the same single-argument pattern.

Found using [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit).

> [!NOTE]
> This PR was authored and submitted by [Claude Code](https://claude.ai/code) (Anthropic).
> It was reviewed by a human before submission.

## Test plan

- [ ] Existing tests pass
- [ ] `_compress_bound` now correctly parses a single unsigned int argument
- [ ] `_compress` returns NULL (not a result) when `update_context_after_process` fails