### PR TITLE
Fix module init error handling in block and stream modules

### DIFF
--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -513,10 +513,16 @@ PyInit__block(void)
   LZ4BlockError = PyErr_NewExceptionWithDoc("_block.LZ4BlockError", "Call to LZ4 library failed.", NULL, NULL);
   if (LZ4BlockError == NULL)
     {
+      Py_DECREF(module);
       return NULL;
     }
   Py_INCREF(LZ4BlockError);
-  PyModule_AddObject(module, "LZ4BlockError", LZ4BlockError);
+  if (PyModule_AddObject(module, "LZ4BlockError", LZ4BlockError) < 0)
+    {
+      Py_DECREF(LZ4BlockError);
+      Py_DECREF(module);
+      return NULL;
+    }
 
   #ifdef Py_GIL_DISABLED
     PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);

--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -1644,10 +1644,16 @@ PyInit__stream(void)
                                               NULL, NULL);
   if (LZ4StreamError == NULL)
     {
+      Py_DECREF (module);
       return NULL;
     }
   Py_INCREF (LZ4StreamError);
-  PyModule_AddObject (module, "LZ4StreamError", LZ4StreamError);
+  if (PyModule_AddObject (module, "LZ4StreamError", LZ4StreamError) < 0)
+    {
+      Py_DECREF (LZ4StreamError);
+      Py_DECREF (module);
+      return NULL;
+    }
 
   #ifdef Py_GIL_DISABLED
     PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);


### PR DESCRIPTION
## Summary

- Add `Py_DECREF(module)` before returning NULL when `PyErr_NewExceptionWithDoc` fails in both `_block` and `_stream` module init — previously leaked the module object
- Check `PyModule_AddObject` return value when adding `LZ4BlockError` and `LZ4StreamError` — previously ignored failures, leaking the exception class reference

## Context

`PyModule_AddObject` steals a reference on success but not on failure. The previous code did not check its return value, so on failure the `Py_INCREF`'d exception class was leaked. The fix checks the return and decrefs both the exception and the module on failure.

Note: `PyModule_AddObjectRef` (Python 3.10+) would simplify this, but the project supports Python 3.9 so we use `PyModule_AddObject` with proper error checking.

Found using [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit).

> [!NOTE]
> This PR was authored and submitted by [Claude Code](https://claude.ai/code) (Anthropic).
> It was reviewed by a human before submission.

## Test plan

- [ ] Existing tests pass
- [ ] Module init failure paths correctly clean up all references