### PR TITLE
Remove dead Python 2.6/MSVC 2008 compat code, use METH_NOARGS for version functions

### DIFF
--- a/lz4/_version.c
+++ b/lz4/_version.c
@@ -36,13 +36,13 @@
 #include <lz4hc.h>
 
 static PyObject *
-library_version_number (PyObject * Py_UNUSED (self), PyObject * Py_UNUSED (args))
+library_version_number (PyObject * Py_UNUSED (self))
 {
   return Py_BuildValue ("i", LZ4_versionNumber ());
 }
 
 static PyObject *
-library_version_string (PyObject * Py_UNUSED (self), PyObject * Py_UNUSED (args))
+library_version_string (PyObject * Py_UNUSED (self))
 {
   return Py_BuildValue ("s", LZ4_versionString ());
 }
@@ -78,13 +78,13 @@ static PyMethodDef module_methods[] = {
   {
     "library_version_number",
     (PyCFunction) library_version_number,
-    METH_VARARGS,
+    METH_NOARGS,
     library_version_number__doc
   },
   {
     "library_version_string",
     (PyCFunction) library_version_string,
-    METH_VARARGS,
+    METH_NOARGS,
     library_version_string__doc
   },
   {

--- a/lz4/block/_block.c
+++ b/lz4/block/_block.c
@@ -42,26 +42,7 @@
 #include <lz4.h>
 #include <lz4hc.h>
 
-#ifndef Py_UNUSED /* This is already defined for Python 3.4 onwards */
-#ifdef __GNUC__
-#define Py_UNUSED(name) _unused_ ## name __attribute__((unused))
-#else
-#define Py_UNUSED(name) _unused_ ## name
-#endif
-#endif
-
-#if defined(_WIN32) && defined(_MSC_VER)
-#if _MSC_VER >= 1600
 #include <stdint.h>
-#else /* _MSC_VER >= 1600 */
-typedef signed char int8_t;
-typedef signed short int16_t;
-typedef signed int int32_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
-#endif /* _MSC_VER >= 1600 */
-#endif
 
 static inline void
 store_le32 (char *c, uint32_t x)

--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -56,13 +56,8 @@ struct compression_context
 static void
 destroy_compression_context (PyObject * py_context)
 {
-#ifndef PyCapsule_Type
   struct compression_context *context =
     PyCapsule_GetPointer (py_context, compression_context_capsule_name);
-#else
-  /* Compatibility with 2.6 via capsulethunk. */
-  struct compression_context *context =  py_context;
-#endif
   Py_BEGIN_ALLOW_THREADS
   LZ4F_freeCompressionContext (context->context);
   Py_END_ALLOW_THREADS
@@ -829,13 +824,8 @@ get_frame_info (PyObject * Py_UNUSED (self), PyObject * args,
 static void
 destroy_decompression_context (PyObject * py_context)
 {
-#ifndef PyCapsule_Type
   LZ4F_dctx * context =
     PyCapsule_GetPointer (py_context, decompression_context_capsule_name);
-#else
-  /* Compatibility with 2.6 via capsulethunk. */
-  LZ4F_dctx * context =  py_context;
-#endif
   Py_BEGIN_ALLOW_THREADS
   LZ4F_freeDecompressionContext (context);
   Py_END_ALLOW_THREADS

--- a/lz4/stream/_stream.c
+++ b/lz4/stream/_stream.c
@@ -44,37 +44,7 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#if defined(_WIN32) && defined(_MSC_VER) && _MSC_VER < 1600
-/* MSVC 2008 and earlier lacks stdint.h */
-typedef signed __int8 int8_t;
-typedef signed __int16 int16_t;
-typedef signed __int32 int32_t;
-typedef signed __int64 int64_t;
-typedef unsigned __int8 uint8_t;
-typedef unsigned __int16 uint16_t;
-typedef unsigned __int32 uint32_t;
-typedef unsigned __int64 uint64_t;
-
-#if !defined(UINT8_MAX)
-#define UINT8_MAX 0xff
-#endif
-#if !defined(UINT16_MAX)
-#define UINT16_MAX 0xffff
-#endif
-#if !defined(UINT32_MAX)
-#define UINT32_MAX 0xffffffff
-#endif
-#if !defined(INT32_MAX)
-#define INT32_MAX 0x7fffffff
-#endif
-#if !defined(CHAR_BIT)
-#define CHAR_BIT 8
-#endif
-
-#else
-/* Not MSVC, or MSVC 2010 or higher */
 #include <stdint.h>
-#endif /* _WIN32 && _MSC_VER && _MSC_VER < 1600 */
 
 #define LZ4_VERSION_NUMBER_1_9_0 10900
 
@@ -219,14 +189,8 @@ struct stream_context_t {
 };
 
 
-#ifndef PyCapsule_Type
 #define _PyCapsule_get_context(py_ctx) \
   ((stream_context_t *) PyCapsule_GetPointer((py_ctx), stream_context_capsule_name))
-#else
-/* Compatibility with 2.6 via capsulethunk. */
-#define _PyCapsule_get_context(py_ctx) \
-  ((stream_context_t *) (py_ctx))
-#endif
 
 
 static inline void


### PR DESCRIPTION
## Summary

- Remove dead `#ifndef PyCapsule_Type` guards in `_frame.c` (2 sites) and `_stream.c` (1 site) — `PyCapsule_Type` is an extern symbol, not a macro, so `#ifndef` is always true. The `#else` branches (Python 2.6 capsulethunk compat) are dead code that unsafely casts `PyObject*` directly to struct pointers.
- Remove dead MSVC 2008 `stdint.h` fallback in `_block.c` and `_stream.c` — MSVC 2008 (`_MSC_VER < 1600`) cannot build Python 3.9+. Replace with unconditional `#include <stdint.h>`.
- Remove dead `#ifndef Py_UNUSED` guard in `_block.c` — `Py_UNUSED` has been defined since Python 3.4, and minimum is 3.9.
- Change `METH_VARARGS` to `METH_NOARGS` for `library_version_number` and `library_version_string` in `_version.c` — these functions take no arguments but `METH_VARARGS` silently accepts and ignores any arguments passed by the caller.

**69 lines of dead code removed.**

Found using [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit).

> [!NOTE]
> This PR was authored and submitted by [Claude Code](https://claude.ai/code) (Anthropic).
> It was reviewed by a human before submission.

## Test plan

- [ ] Existing tests pass
- [ ] `library_version_string()` still works
- [ ] `library_version_string(1, 2, 3)` now raises `TypeError` instead of silently succeeding