### PR TITLE
Fix failing GitHub Actions by not upgrading pypa/cibuildwheel

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -78,7 +78,7 @@ jobs:
           echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False" >> "$GITHUB_ENV"
           echo "CIBW_TEST_COMMAND=tox -c {project}" >> "$GITHUB_ENV"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
+        uses: pypa/cibuildwheel@v3.3.0
         env:
           # CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
           CIBW_ARCHS_LINUX: "x86_64 i686"
@@ -128,7 +128,7 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
           CIBW_ENABLE: cpython-freethreading
-          CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
+          CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox virtualenv"
       - name: Save wheels
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
       - name: Save sdist
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-sdist.tar.gz
           path: dist/*.tar.gz
@@ -60,7 +60,7 @@ jobs:
           python-version: 3.x
       - name: Set up QEMU # Needed to build aarch64 wheels
         if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
 
@@ -78,7 +78,7 @@ jobs:
           echo "CIBW_ENVIRONMENT=PYLZ4_USE_SYSTEM_LZ4=False" >> "$GITHUB_ENV"
           echo "CIBW_TEST_COMMAND=tox -c {project}" >> "$GITHUB_ENV"
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.3.0
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           # CIBW_ARCHS_LINUX: "x86_64 i686 aarch64"
           CIBW_ARCHS_LINUX: "x86_64 i686"
@@ -88,9 +88,9 @@ jobs:
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: "cp*-musllinux*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-*linux_{ppc64le,s390x} *-win_arm64"
-          CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
+          CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox virtualenv"
       - name: Save wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -130,7 +130,7 @@ jobs:
           CIBW_ENABLE: cpython-freethreading
           CIBW_BEFORE_BUILD: "python -m pip install -U pip && python -m pip install tox"
       - name: Save wheels
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           pattern: cibw-*
           path: dist


### PR DESCRIPTION
* #337 

Fix the failing GitHub Actions in #337 by upgrading `virtualenv` and NOT upgrading `pypa/cibuildwheel`.
