### PR TITLE
frame: support importing under sub-interpreters

### DIFF
--- a/lz4/frame/_frame.c
+++ b/lz4/frame/_frame.c
@@ -1654,23 +1654,9 @@ PyDoc_STRVAR(lz4frame__doc,
              "A Python wrapper for the LZ4 frame protocol"
              );
 
-static struct PyModuleDef moduledef =
+static int
+_frame_exec (PyObject *module)
 {
-  PyModuleDef_HEAD_INIT,
-  "_frame",
-  lz4frame__doc,
-  -1,
-  module_methods
-};
-
-PyMODINIT_FUNC
-PyInit__frame(void)
-{
-  PyObject *module = PyModule_Create (&moduledef);
-
-  if (module == NULL)
-    return NULL;
-
   PyModule_AddIntConstant (module, "BLOCKSIZE_DEFAULT", LZ4F_default);
   PyModule_AddIntConstant (module, "BLOCKSIZE_MAX64KB", LZ4F_max64KB);
   PyModule_AddIntConstant (module, "BLOCKSIZE_MAX256KB", LZ4F_max256KB);
@@ -1681,5 +1667,32 @@ PyInit__frame(void)
     PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
   #endif
 
-  return module;
+  return 0;
+}
+
+static PyModuleDef_Slot _frame_slots[] =
+{
+  {Py_mod_exec, _frame_exec},
+#if PY_VERSION_HEX >= 0x030c0000
+  /* No shared global state: each context is allocated per call, so _frame is
+     safe in isolated sub-interpreters that each have their own GIL. */
+  {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+  {0, NULL},
+};
+
+static struct PyModuleDef moduledef =
+{
+  .m_base = PyModuleDef_HEAD_INIT,
+  .m_name = "_frame",
+  .m_doc = lz4frame__doc,
+  .m_size = 0,
+  .m_methods = module_methods,
+  .m_slots = _frame_slots,
+};
+
+PyMODINIT_FUNC
+PyInit__frame(void)
+{
+  return PyModuleDef_Init (&moduledef);
 }


### PR DESCRIPTION
## What

Python 3.12+ won't import single-phase C extensions inside a sub-interpreter.
This converts `_frame` to multi-phase init so it imports there, and declares it
safe to run with a per-interpreter GIL.

Part of #345 - multi-phase init for the `_frame` module (see also #341 `_block`, #342 `_stream`, #343 `_version`).

## Why it's safe

`_frame` keeps no shared global state: each compression/decompression context is
allocated per call and freed with the object it's wrapped in, and there are no
custom module globals or static types. The bundled liblz4 is reentrant. So the
module is safe even in fully isolated interpreters.

## Compatibility

No API change. The new declaration is guarded for Python 3.12+, so builds on
older Python are unaffected.

## Scope

This covers the `frame` submodule only. `block`, `stream`, and `_version` are
still single-phase, so `import lz4` as a whole doesn't work under a
sub-interpreter yet — those are follow-ups. This PR makes the `_frame` extension
itself compatible, which is the foundation for the rest.

## Testing

- `tests/frame/` passes (12,587 tests).
- Verified `_frame` imports and round-trips inside an isolated, own-GIL
  sub-interpreter (checked with both the `_xxsubinterpreters` API and a C harness
  that enables the multi-interpreter check).

Refs: [PEP 489](https://peps.python.org/pep-0489/), [Isolating Extension Modules](https://docs.python.org/3/howto/isolating-extensions.html)