### PR TITLE
version: support importing under sub-interpreters

### DIFF
--- a/lz4/_version.c
+++ b/lz4/_version.c
@@ -96,26 +96,39 @@ static PyMethodDef module_methods[] = {
   }
 };
 
+static int
+_version_exec (PyObject *module)
+{
+  #ifdef Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL (module, Py_MOD_GIL_NOT_USED);
+  #endif
+
+  return 0;
+}
+
+static PyModuleDef_Slot _version_slots[] =
+  {
+    {Py_mod_exec, _version_exec},
+#if PY_VERSION_HEX >= 0x030c0000
+    /* No state and the LZ4 version calls are reentrant, so _version is safe in
+       isolated sub-interpreters with their own GIL. */
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+    {0, NULL},
+  };
+
 static struct PyModuleDef moduledef =
   {
-    PyModuleDef_HEAD_INIT,
-    "_version",
-    NULL,
-    -1,
-    module_methods
+    .m_base    = PyModuleDef_HEAD_INIT,
+    .m_name    = "_version",
+    .m_doc     = NULL,
+    .m_size    = 0,
+    .m_methods = module_methods,
+    .m_slots   = _version_slots,
   };
 
 PyMODINIT_FUNC
 PyInit__version(void)
 {
-  PyObject *module = PyModule_Create (&moduledef);
-
-  if (module == NULL)
-    return NULL;
-
-  #ifdef Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
-  #endif
-
-  return module;
+  return PyModuleDef_Init (&moduledef);
 }


### PR DESCRIPTION
## What


Make `import lz4` work inside a sub-interpreter. Python 3.12+ won't import single-phase C extensions in a sub-interpreter, and `lz4/__init__.py` imports `_version` — so today `import lz4` fails there with `ImportError: module _version does not support loading in subinterpreters`. This converts `_version` to multi-phase init and declares it safe under a per-interpreter GIL.

Part of #345 - multi-phase init for the `_version` module (see also #340 `_frame`, #341 `_block`, #342 `_stream`).

## Relationship to the other PRs

Part of a series making the whole package sub-interpreter-compatible: #340 (frame), #341 (block), #342 (stream), and this one (`_version`).

These are independent and can merge in any order. They touch different files and don't conflict. But this PR is the gate: because `import lz4` (and therefore any `import lz4.frame` / `lz4.block` / `lz4.stream`, which import the parent package first) goes through `_version`, the normal import paths stay blocked in a sub-interpreter until this one lands. With all four in, the whole package loads and round-trips in an isolated, own-GIL sub-interpreter.

## Why it's safe

`_version` has no module state and just wraps the reentrant LZ4 version calls, so it is safe even in fully isolated interpreters. This is a mechanical conversion.

## Compatibility

No API change. The new declaration is guarded for Python 3.12+, so builds on older Python are unaffected.

## Testing

- Version tests pass.
- Verified `import lz4` succeeds in an isolated, own-GIL sub-interpreter.

Refs: [PEP 489](https://peps.python.org/pep-0489/), [Isolating Extension Modules](https://docs.python.org/3/howto/isolating-extensions.html)